### PR TITLE
Fix Makefile indentation for ROOT dictionary target

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -101,12 +101,13 @@ ROOT_DICT_SRC := $(ROOT_SHARED_LIB_NAME)_dict.cxx
 ROOT_DICT_OBJ := $(ROOT_SHARED_LIB_NAME)_dict.o
 ROOT_DICT_PCM := $(ROOT_SHARED_LIB_NAME)_dict_rdict.pcm
 
+
 $(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h \
-        $(INCLUDE_DIR)/rarexsec/EventProcessor.h \
-        $(INCLUDE_DIR)/rarexsec/PreSelection.h \
-        $(INCLUDE_DIR)/rarexsec/MuonSelector.h \
-        $(INCLUDE_DIR)/rarexsec/TruthClassifier.h
-        $(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
+	$(INCLUDE_DIR)/rarexsec/EventProcessor.h \
+	$(INCLUDE_DIR)/rarexsec/PreSelection.h \
+	$(INCLUDE_DIR)/rarexsec/MuonSelector.h \
+	$(INCLUDE_DIR)/rarexsec/TruthClassifier.h
+	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
         $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
                 rarexsec/EventProcessor.h \
                 rarexsec/PreSelection.h \


### PR DESCRIPTION
## Summary
- replace the space-indented commands in the ROOT dictionary rule with tabs so GNU make accepts the recipe

## Testing
- `make` *(fails: ROOT headers such as ROOT/RVec.hxx are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7aa29e78832ebf844baa2cc844a4