### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -108,13 +108,13 @@ $(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h \
 	$(INCLUDE_DIR)/rarexsec/MuonSelector.h \
 	$(INCLUDE_DIR)/rarexsec/TruthClassifier.h
 	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
-        $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
-                rarexsec/EventProcessor.h \
-                rarexsec/PreSelection.h \
-                rarexsec/MuonSelector.h \
-                rarexsec/TruthClassifier.h \
-                $(SRC_DIR)/rarexsecLinkDef.h
-        $(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -I$(INCLUDE_DIR) -fPIC -o $@ -c $(ROOT_DICT_SRC)
+	$(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
+		rarexsec/EventProcessor.h \
+		rarexsec/PreSelection.h \
+		rarexsec/MuonSelector.h \
+		rarexsec/TruthClassifier.h \
+		$(SRC_DIR)/rarexsecLinkDef.h
+	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -I$(INCLUDE_DIR) -fPIC -o $@ -c $(ROOT_DICT_SRC)
 
 $(ROOT_SHARED_LIB): $(SHARED_LIB) $(ROOT_DICT_OBJ)
 	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $(ROOT_DICT_OBJ) -L. -l$(PROJECT_SHARED_LIB_NAME) $(ROOT_LDFLAGS) $(ROOT_LIBS)


### PR DESCRIPTION
## Summary
- replace space-indented recipe lines in the ROOT dictionary rule with tabs so GNU make accepts the file

## Testing
- make *(fails: missing ROOT/RVec.hxx in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7bf97108832ea5d6bdcf7a428642