### PR TITLE
Refine build Makefile for modular library outputs

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,25 +1,37 @@
-TOP_DIR := $(shell cd .. && pwd)
+TOP_DIR := $(abspath ..)
 INCLUDE_DIR := $(TOP_DIR)/include
 SRC_DIR := $(TOP_DIR)/src
 BUILD_DIR := $(TOP_DIR)/build
+OBJ_DIR := $(BUILD_DIR)/obj
+LIB_DIR := $(BUILD_DIR)/lib
+
+PROJECT_SHARED_LIB_NAME := rarexsec
+ROOT_SHARED_LIB_NAME := rarexsec_root
+SHARED_LIB := $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME)
+ROOT_SHARED_LIB := $(LIB_DIR)/lib$(ROOT_SHARED_LIB_NAME)
+
+MKDIR := mkdir -p
+RM := rm -f
+RMDIR := rm -rf
+AR ?= ar
 
 CXX_STD ?= c++17
 UNKNOWN_REV := unknown version
 
-ifeq ($(MAKECMDGOALS),debug)
-  override CXXFLAGS := -std=$(CXX_STD) $(CXXFLAGS) -O0 -g
-else
-  override CXXFLAGS := -O3 -std=$(CXX_STD) $(CXXFLAGS)
-endif
+ROOTCXX := $(shell root-config --cxx 2> /dev/null)
+	CXX ?= $(if $(ROOTCXX),$(ROOTCXX),g++)
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-  SHARED_LIB_SUFFIX := dylib
+  SOEXT := dylib
+  SHARED_LDFLAGS := -dynamiclib
 else ifeq ($(UNAME_S),Linux)
-  SHARED_LIB_SUFFIX := so
+  SOEXT := so
+  SHARED_LDFLAGS := -shared
 else
   $(warning Unrecognized operating system encountered.)
-  SHARED_LIB_SUFFIX := so
+  SOEXT := so
+  SHARED_LDFLAGS := -shared
 endif
 
 GIT := $(shell command -v git 2> /dev/null)
@@ -27,38 +39,23 @@ GIT := $(shell command -v git 2> /dev/null)
 ifndef GIT
   GIT_REVISION := $(UNKNOWN_REV)
 else
-  GIT_REVPARSE_CODE := $(shell git rev-parse 2> /dev/null && echo "$$?")
-  ifeq ($(GIT_REVPARSE_CODE),0)
-    GIT_REVISION := $(shell git rev-parse --short HEAD)
-    GIT_DIFF_INDEX_CODE := $(shell git diff-index --quiet HEAD 2> /dev/null && echo "$$?")
-    ifneq ($(GIT_DIFF_INDEX_CODE),0)
+  GIT_REVPARSE_CODE := $(shell $(GIT) -C $(TOP_DIR) rev-parse 2> /dev/null && echo "$$?")
+	  ifeq ($(GIT_REVPARSE_CODE),0)
+    GIT_REVISION := $(shell $(GIT) -C $(TOP_DIR) rev-parse --short HEAD)
+    GIT_DIFF_INDEX_CODE := $(shell $(GIT) -C $(TOP_DIR) diff-index --quiet HEAD 2> /dev/null; echo "$$?")
+	    ifneq ($(GIT_DIFF_INDEX_CODE),0)
       GIT_REVISION := $(GIT_REVISION)-dirty
-    endif
-  else
+	    endif
+	  else
     GIT_REVISION := $(UNKNOWN_REV)
-  endif
+	  endif
 endif
 
-ifneq (,$(wildcard ../.VERSION))
-  PROJECT_VERSION := $(shell cat ../.VERSION)
+ifneq (,$(wildcard $(TOP_DIR)/.VERSION))
+  PROJECT_VERSION := $(shell cat $(TOP_DIR)/.VERSION)
 else
   PROJECT_VERSION := $(GIT_REVISION)
 endif
-
-override CXXFLAGS += -DRAREXSEC_VERSION=\"$(PROJECT_VERSION)\"
-
-PROJECT_SHARED_LIB_NAME := rarexsec
-SHARED_LIB := lib$(PROJECT_SHARED_LIB_NAME).$(SHARED_LIB_SUFFIX)
-ROOT_SHARED_LIB_NAME := rarexsec_root
-ROOT_SHARED_LIB := lib$(ROOT_SHARED_LIB_NAME).$(SHARED_LIB_SUFFIX)
-
-CXX ?= g++
-override CXXFLAGS += -I$(INCLUDE_DIR) -Wall -Wextra -Wpedantic
-LDFLAGS ?=
-
-SOURCES := $(wildcard $(SRC_DIR)/*.cc)
-OBJECTS := $(notdir $(SOURCES:.cc=.o))
-OBJECTS := $(filter-out $(ROOT_SHARED_LIB_NAME)_dict.o,$(OBJECTS))
 
 ROOTCONFIG := $(shell command -v root-config 2> /dev/null)
 ROOT := $(shell command -v root 2> /dev/null)
@@ -68,62 +65,150 @@ ifndef ROOTCLING
 endif
 
 ifeq ($(ROOTCONFIG),)
-  $(info ROOT not found. Building without dictionary support.)
+  $(warning ROOT not found. Dictionary library will not be built.)
+  USE_ROOT := no
+else ifeq ($(ROOTCLING),)
+  $(warning ROOT dictionary tool (rootcling/rootcint) not found. Dictionary library will not be built.)
   USE_ROOT := no
 else
   ROOT_VERSION := $(shell $(ROOTCONFIG) --version)
-  $(info Found ROOT version $(ROOT_VERSION) in $(ROOT))
+	  $(info Found ROOT version $(ROOT_VERSION) in $(ROOT))
   USE_ROOT := yes
   ROOT_CXXFLAGS := $(shell $(ROOTCONFIG) --cflags)
   ROOT_LDFLAGS := $(shell $(ROOTCONFIG) --ldflags)
   ROOT_LIBS := $(shell $(ROOTCONFIG) --libs)
 endif
 
-ALL_TARGETS := $(SHARED_LIB)
-ifeq ($(USE_ROOT),yes)
-  ALL_TARGETS += $(ROOT_SHARED_LIB)
+EXTRA_INC ?=
+EXTRA_CXXFLAGS ?=
+EXTRA_LDFLAGS ?=
+EXTRA_LIBS ?=
+
+OPTFLAGS := -O3
+ifeq ($(MAKECMDGOALS),debug)
+  OPTFLAGS := -O0 -g
 endif
+
+USER_CXXFLAGS := $(CXXFLAGS)
+USER_LDFLAGS := $(LDFLAGS)
+
+BASE_CXXFLAGS := -std=$(CXX_STD) -Wall -Wextra -Wpedantic -fPIC -I$(INCLUDE_DIR) \
+	                  $(ROOT_CXXFLAGS) $(EXTRA_INC) $(EXTRA_CXXFLAGS) \
+	                  -DRAREXSEC_VERSION=\"$(PROJECT_VERSION)\"
+CXXFLAGS := $(OPTFLAGS) $(BASE_CXXFLAGS) $(USER_CXXFLAGS)
+
+LINK_FLAGS := $(ROOT_LDFLAGS) $(EXTRA_LDFLAGS) $(USER_LDFLAGS)
+LDLIBS := $(ROOT_LIBS) $(EXTRA_LIBS)
+
+SRCS_CC := $(shell find $(SRC_DIR) -type f -name '*.cc' 2> /dev/null)
+SRCS_CPP := $(shell find $(SRC_DIR) -type f -name '*.cpp' 2> /dev/null)
+SRCS := $(SRCS_CC) $(SRCS_CPP)
+
+OBJS := $(SRCS_CC:$(SRC_DIR)/%.cc=$(OBJ_DIR)/%.o) \
+        $(SRCS_CPP:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
+OBJS := $(filter-out $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict.o,$(OBJS))
+
+ifeq ($(strip $(SRCS)),)
+  $(warning No sources found under '$(SRC_DIR)'.)
+endif
+
+ROOT_DICT_HEADERS_REL := rarexsec/EventProcessor.h rarexsec/PreSelection.h rarexsec/MuonSelector.h rarexsec/TruthClassifier.h
+ROOT_DICT_HEADERS := $(addprefix $(INCLUDE_DIR)/,$(ROOT_DICT_HEADERS_REL))
+ROOT_DICT_SRC := $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict.cxx
+ROOT_DICT_OBJ := $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict.o
+ROOT_DICT_PCM := $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict_rdict.pcm
+
+ALL_TARGETS := $(SHARED_LIB).$(SOEXT) $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a
+ifeq ($(USE_ROOT),yes)
+  ALL_TARGETS += $(ROOT_SHARED_LIB).$(SOEXT)
+endif
+
+.PHONY: all debug shared static rootlib install run clean distclean print
 
 all: $(ALL_TARGETS)
 
+shared: $(SHARED_LIB).$(SOEXT)
+
+static: $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a
+
+rootlib: $(ROOT_SHARED_LIB).$(SOEXT)
+
 debug: $(ALL_TARGETS)
 
-.INTERMEDIATE: $(OBJECTS)
+$(LIB_DIR) $(OBJ_DIR):
+	@$(MKDIR) $@
 
-%.o: $(SRC_DIR)/%.cc
-	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -fPIC -o $@ -c $<
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cc | $(OBJ_DIR)
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
-$(SHARED_LIB): $(OBJECTS)
-	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $^ $(LDFLAGS)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp | $(OBJ_DIR)
+	@$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) -MMD -MP -c $< -o $@
+
+$(SHARED_LIB).$(SOEXT): $(OBJS) | $(LIB_DIR)
+	$(CXX) $(SHARED_LDFLAGS) -o $@ $^ $(LINK_FLAGS) $(LDLIBS)
+	@echo "Built $@"
+
+$(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a: $(OBJS) | $(LIB_DIR)
+	$(AR) rcs $@ $^
+	@echo "Built $@"
 
 ifeq ($(USE_ROOT),yes)
-ROOT_DICT_SRC := $(ROOT_SHARED_LIB_NAME)_dict.cxx
-ROOT_DICT_OBJ := $(ROOT_SHARED_LIB_NAME)_dict.o
-ROOT_DICT_PCM := $(ROOT_SHARED_LIB_NAME)_dict_rdict.pcm
-
-
-$(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h \
-	$(INCLUDE_DIR)/rarexsec/EventProcessor.h \
-	$(INCLUDE_DIR)/rarexsec/PreSelection.h \
-	$(INCLUDE_DIR)/rarexsec/MuonSelector.h \
-	$(INCLUDE_DIR)/rarexsec/TruthClassifier.h
+$(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h $(ROOT_DICT_HEADERS) | $(OBJ_DIR)
+	@$(MKDIR) $(dir $@)
 	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
-        $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
-                rarexsec/EventProcessor.h \
-                rarexsec/PreSelection.h \
-                rarexsec/MuonSelector.h \
-                rarexsec/TruthClassifier.h \
-                $(SRC_DIR)/rarexsecLinkDef.h
-        $(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -I$(INCLUDE_DIR) -fPIC -o $@ -c $(ROOT_DICT_SRC)
+	$(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
+	$(ROOT_DICT_HEADERS_REL) \
+	$(SRC_DIR)/rarexsecLinkDef.h
+	$(CXX) $(CXXFLAGS) -MMD -MP -c $(ROOT_DICT_SRC) -o $@
 
-$(ROOT_SHARED_LIB): $(SHARED_LIB) $(ROOT_DICT_OBJ)
-	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $(ROOT_DICT_OBJ) -L. -l$(PROJECT_SHARED_LIB_NAME) $(ROOT_LDFLAGS) $(ROOT_LIBS)
+$(ROOT_SHARED_LIB).$(SOEXT): $(SHARED_LIB).$(SOEXT) $(ROOT_DICT_OBJ) | $(LIB_DIR)
+	$(CXX) $(SHARED_LDFLAGS) -o $@ $(ROOT_DICT_OBJ) -L$(LIB_DIR) -l$(PROJECT_SHARED_LIB_NAME) $(LINK_FLAGS) $(LDLIBS)
+	@echo "Built $@"
 endif
+
+PREFIX ?= $(TOP_DIR)/install
+INSTALL_LIBDIR := $(PREFIX)/lib
+INSTALL_INCDIR := $(PREFIX)/include
+
+install: all
+	@$(MKDIR) $(INSTALL_LIBDIR) $(INSTALL_INCDIR)
+	@cp -a $(SHARED_LIB).$(SOEXT) $(INSTALL_LIBDIR)/
+	@cp -a $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a $(INSTALL_LIBDIR)/
+ifeq ($(USE_ROOT),yes)
+	@cp -a $(ROOT_SHARED_LIB).$(SOEXT) $(INSTALL_LIBDIR)/
+endif
+	@rsync -a --delete $(INCLUDE_DIR)/ $(INSTALL_INCDIR)/
+	@echo "Installed to $(PREFIX)"
+	@echo "  - libs:    $(INSTALL_LIBDIR)"
+	@echo "  - headers: $(INSTALL_INCDIR)"
+
+run: $(SHARED_LIB).$(SOEXT)
+	@test -n "$(ROOT)" || (echo "ROOT executable not found" && exit 1)
+	@root -l -q -e 'gSystem->Load("$(abspath $(SHARED_LIB)).$(SOEXT)"); \
+	                 gSystem->AddIncludePath("-I$(abspath $(INCLUDE_DIR))"); \
+	                 gROOT->ProcessLine(".x $(MACRO)$(ARGS)");'
+
+print:
+	@echo "CXX           = $(CXX)"
+	@echo "CXXFLAGS      = $(CXXFLAGS)"
+	@echo "LINK_FLAGS    = $(LINK_FLAGS)"
+	@echo "LDLIBS        = $(LDLIBS)"
+	@echo "SRCS          = $(SRCS)"
+	@echo "OBJS          = $(OBJS)"
+	@echo "LIB_DIR       = $(LIB_DIR)"
+	@echo "SOEXT         = $(SOEXT)"
 
 clean:
-	$(RM) $(SHARED_LIB) $(ROOT_SHARED_LIB) $(OBJECTS)
+	$(RMDIR) $(OBJ_DIR) $(LIB_DIR)
+
+distclean: clean
+	$(RMDIR) $(PREFIX)
+
+DEPS := $(OBJS:.o=.d)
 ifeq ($(USE_ROOT),yes)
-	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_OBJ) $(ROOT_DICT_PCM)
+DEPS += $(ROOT_DICT_OBJ:.o=.d)
 endif
 
-.PHONY: all debug clean
+-include $(DEPS)


### PR DESCRIPTION
## Summary
- reorganize build directories and targets to build both shared and static rarexsec libraries
- add automatic dependency generation, install/run helpers, and optional ROOT dictionary build
- improve toolchain detection, version stamping, and user extensibility flags

## Testing
- make print

------
https://chatgpt.com/codex/tasks/task_e_68da7c5c8d90832ebd815b1d9b6ce7e1