### PR TITLE
Add helper scripts and config generation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,9 +1,26 @@
-TOP_DIR := $(shell cd .. && pwd)
-INCLUDE_DIR := $(TOP_DIR)/include
-SRC_DIR := $(TOP_DIR)/src
-BUILD_DIR := $(TOP_DIR)/build
+TOPDIR := $(shell cd .. && pwd)
+INCDIR := $(TOPDIR)/include
+SRC_DIR := $(TOPDIR)/src
+BUILDDIR := $(TOPDIR)/build
+LIBDIR := $(BUILDDIR)/lib
+BINDIR := $(BUILDDIR)/bin
 
-CXX_STD ?= c++17
+SCRIPTDIR   := $(TOPDIR)/scripts
+VERSION     ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo 0.0.0)
+GIT_REV     := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+CXX_STD     ?= c++17
+USE_ROOT    ?= yes
+
+CONFIG_IN   := $(SCRIPTDIR)/rarexsec-config.in
+CONFIG_OUT  := $(BINDIR)/rarexsec-config
+ROOT_WRAPPER:= $(SCRIPTDIR)/rarexsec-root.sh
+SETUP_MACRO := $(SCRIPTDIR)/setup_rarexsec.C
+
+MKDIR := mkdir -p
+PREFIX ?= /usr/local
+INSTALL_LIBDIR := $(PREFIX)/lib
+INSTALL_INCDIR := $(PREFIX)/include
+
 UNKNOWN_REV := unknown version
 
 ifeq ($(MAKECMDGOALS),debug)
@@ -12,14 +29,16 @@ else
   override CXXFLAGS := -O3 -std=$(CXX_STD) $(CXXFLAGS)
 endif
 
+CXX_STD_STR := $(or $(patsubst -std=%,%,$(filter -std=%,$(CXXFLAGS))),$(CXX_STD))
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-  SHARED_LIB_SUFFIX := dylib
+  SOEXT := dylib
 else ifeq ($(UNAME_S),Linux)
-  SHARED_LIB_SUFFIX := so
+  SOEXT := so
 else
   $(warning Unrecognized operating system encountered.)
-  SHARED_LIB_SUFFIX := so
+  SOEXT := so
 endif
 
 GIT := $(shell command -v git 2> /dev/null)
@@ -45,15 +64,17 @@ else
   PROJECT_VERSION := $(GIT_REVISION)
 endif
 
+VERSION := $(PROJECT_VERSION)
+GIT_REV := $(GIT_REVISION)
+
+override CXXFLAGS += -I$(INCDIR) -Wall -Wextra -Wpedantic
 override CXXFLAGS += -DRAREXSEC_VERSION=\"$(PROJECT_VERSION)\"
 
-PROJECT_SHARED_LIB_NAME := rarexsec
-SHARED_LIB := lib$(PROJECT_SHARED_LIB_NAME).$(SHARED_LIB_SUFFIX)
+LIBNAME := rarexsec
 ROOT_SHARED_LIB_NAME := rarexsec_root
-ROOT_SHARED_LIB := lib$(ROOT_SHARED_LIB_NAME).$(SHARED_LIB_SUFFIX)
 
 CXX ?= g++
-override CXXFLAGS += -I$(INCLUDE_DIR) -Wall -Wextra -Wpedantic
+AR ?= ar
 LDFLAGS ?=
 
 SOURCES := $(wildcard $(SRC_DIR)/*.cc)
@@ -79,51 +100,86 @@ else
   ROOT_LIBS := $(shell $(ROOTCONFIG) --libs)
 endif
 
-ALL_TARGETS := $(SHARED_LIB)
+SHARED_LIB := $(LIBDIR)/lib$(LIBNAME).$(SOEXT)
+STATIC_LIB := $(LIBDIR)/lib$(LIBNAME).a
+ROOT_SHARED_LIB := $(LIBDIR)/lib$(ROOT_SHARED_LIB_NAME).$(SOEXT)
+
+ALL_TARGETS := $(SHARED_LIB) $(STATIC_LIB)
 ifeq ($(USE_ROOT),yes)
   ALL_TARGETS += $(ROOT_SHARED_LIB)
 endif
 
-all: $(ALL_TARGETS)
+all: $(ALL_TARGETS) $(CONFIG_OUT)
 
-debug: $(ALL_TARGETS)
+debug: $(ALL_TARGETS) $(CONFIG_OUT)
 
 .INTERMEDIATE: $(OBJECTS)
+
+$(LIBDIR):
+	@$(MKDIR) $@
+
+$(BINDIR):
+	@$(MKDIR) $@
 
 %.o: $(SRC_DIR)/%.cc
 	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -fPIC -o $@ -c $<
 
-$(SHARED_LIB): $(OBJECTS)
+$(SHARED_LIB): $(OBJECTS) | $(LIBDIR)
 	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $^ $(LDFLAGS)
+
+$(STATIC_LIB): $(OBJECTS) | $(LIBDIR)
+	$(AR) rcs $@ $^
 
 ifeq ($(USE_ROOT),yes)
 ROOT_DICT_SRC := $(ROOT_SHARED_LIB_NAME)_dict.cxx
 ROOT_DICT_OBJ := $(ROOT_SHARED_LIB_NAME)_dict.o
 ROOT_DICT_PCM := $(ROOT_SHARED_LIB_NAME)_dict_rdict.pcm
 
-
 $(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h \
-	$(INCLUDE_DIR)/rarexsec/EventProcessor.h \
-	$(INCLUDE_DIR)/rarexsec/PreSelection.h \
-	$(INCLUDE_DIR)/rarexsec/MuonSelector.h \
-	$(INCLUDE_DIR)/rarexsec/TruthClassifier.h
+        $(INCDIR)/rarexsec/EventProcessor.h \
+        $(INCDIR)/rarexsec/PreSelection.h \
+        $(INCDIR)/rarexsec/MuonSelector.h \
+        $(INCDIR)/rarexsec/TruthClassifier.h
 	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
-        $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
+	$(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCDIR) \
                 rarexsec/EventProcessor.h \
                 rarexsec/PreSelection.h \
                 rarexsec/MuonSelector.h \
                 rarexsec/TruthClassifier.h \
                 $(SRC_DIR)/rarexsecLinkDef.h
-        $(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -I$(INCLUDE_DIR) -fPIC -o $@ -c $(ROOT_DICT_SRC)
+	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -I$(INCDIR) -fPIC -o $@ -c $(ROOT_DICT_SRC)
 
-$(ROOT_SHARED_LIB): $(SHARED_LIB) $(ROOT_DICT_OBJ)
-	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $(ROOT_DICT_OBJ) -L. -l$(PROJECT_SHARED_LIB_NAME) $(ROOT_LDFLAGS) $(ROOT_LIBS)
+$(ROOT_SHARED_LIB): $(SHARED_LIB) $(ROOT_DICT_OBJ) | $(LIBDIR)
+	$(CXX) $(ROOT_CXXFLAGS) $(CXXFLAGS) -shared -o $@ $(ROOT_DICT_OBJ) -L$(LIBDIR) -l$(LIBNAME) $(ROOT_LDFLAGS) $(ROOT_LIBS)
 endif
+
+$(CONFIG_OUT): $(CONFIG_IN) | $(BINDIR)
+	sed -e 's|@@VERSION@@|$(VERSION)|g' \
+    -e 's|@@GIT_REVISION@@|$(GIT_REV)|g' \
+    -e 's|@@CXX_STD@@|$(CXX_STD_STR)|g' \
+    -e 's|@@USE_ROOT@@|$(USE_ROOT)|g' \
+    $< > $@
+	chmod +x $@
+
+install: all
+	@$(MKDIR) $(INSTALL_LIBDIR) $(INSTALL_INCDIR) $(PREFIX)/bin $(PREFIX)/scripts
+	@cp -a $(SHARED_LIB) $(INSTALL_LIBDIR)/
+	@cp -a $(STATIC_LIB) $(INSTALL_LIBDIR)/
+ifeq ($(USE_ROOT),yes)
+	@cp -a $(ROOT_SHARED_LIB) $(INSTALL_LIBDIR)/
+endif
+	@rsync -a --delete $(INCDIR)/ $(INSTALL_INCDIR)/
+	@cp -a $(CONFIG_OUT) $(PREFIX)/bin/
+	@cp -a $(ROOT_WRAPPER) $(PREFIX)/bin/rarexsec-root
+	@cp -a $(SETUP_MACRO) $(PREFIX)/scripts/
+	@echo "Installed helper scripts to $(PREFIX)/bin and macro to $(PREFIX)/scripts"
 
 clean:
-	$(RM) $(SHARED_LIB) $(ROOT_SHARED_LIB) $(OBJECTS)
+	$(RM) $(OBJECTS) $(STATIC_LIB) $(SHARED_LIB) $(CONFIG_OUT)
 ifeq ($(USE_ROOT),yes)
-	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_OBJ) $(ROOT_DICT_PCM)
+	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_OBJ) $(ROOT_DICT_PCM) $(ROOT_SHARED_LIB)
+else
+	$(RM) $(ROOT_SHARED_LIB)
 endif
 
-.PHONY: all debug clean
+.PHONY: all debug clean install

--- a/scripts/rarexsec-config.in
+++ b/scripts/rarexsec-config.in
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# rarexsec-config — print compiler/linker flags and paths for rarexsec
+
+# Resolve topdir: prefer RAREXSEC env; else derive from this script location
+if [ -z "$RAREXSEC" ]; then
+  topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+else
+  topdir=${RAREXSEC}
+fi
+
+bindir=${topdir}/build/bin
+datadir=${topdir}/data
+incdir=${topdir}/include
+libdir=${topdir}/build/lib
+srcdir=${topdir}/src
+
+version=@@VERSION@@
+git_rev=@@GIT_REVISION@@
+cxx_std=@@CXX_STD@@
+use_root=@@USE_ROOT@@
+
+root_cflags=""
+root_libs=""
+if [ "$use_root" = "yes" ]; then
+  root_cflags="$(root-config --cflags) -DUSE_ROOT"
+  root_libs="$(root-config --libs)"
+fi
+
+cflags="${root_cflags} -std=${cxx_std} -I${incdir}"
+libs="-L${libdir} -lrarexsec ${root_libs}"
+
+usage="Usage: rarexsec-config [--bindir] [--cflags] [--cxx-std] [--datadir] \
+[--libs] [--libdir] [--incdir] [--srcdir] [--topdir] [--use-root] \
+[--version] [--git-revision] [--help]"
+
+if [ $# -eq 0 ]; then echo "${usage}"; exit 1; fi
+for arg in "$@"; do
+  case $arg in
+    --help) echo "${usage}"; exit 0;;
+    --cflags)        out="$out $cflags" ;;
+    --cxx-std)       out="$out $cxx_std" ;;
+    --bindir)        out="$out $bindir" ;;
+    --datadir)       out="$out $datadir" ;;
+    --libs)          out="$out $libs" ;;
+    --libdir)        out="$out $libdir" ;;
+    --incdir)        out="$out $incdir" ;;
+    --srcdir)        out="$out $srcdir" ;;
+    --topdir)        out="$out $topdir" ;;
+    --use-root)      out="$out $use_root" ;;
+    --version)       out="$out $version" ;;
+    --git-revision)  out="$out $git_rev" ;;
+    *) echo "Unknown arg: $arg"; echo "${usage}"; exit 3;;
+  esac
+done
+echo $out

--- a/scripts/rarexsec-root.sh
+++ b/scripts/rarexsec-root.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+# Determine topdir from RAREXSEC or script path
+if [ -z "$RAREXSEC" ]; then
+  TOPDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+else
+  TOPDIR="$RAREXSEC"
+fi
+LIBDIR="${TOPDIR}/build/lib"
+INCDIR="${TOPDIR}/include"
+MACRO="${TOPDIR}/scripts/setup_rarexsec.C"
+
+# Ensure library path and includes are visible to ROOT
+case "$(uname -s)" in
+  Darwin) export DYLD_LIBRARY_PATH="${LIBDIR}:${DYLD_LIBRARY_PATH}" ;;
+  *)      export LD_LIBRARY_PATH="${LIBDIR}:${LD_LIBRARY_PATH}" ;;
+esac
+export ROOT_INCLUDE_PATH="${INCDIR}:${ROOT_INCLUDE_PATH}"
+
+libext=$([ "$(uname -s)" = Darwin ] && echo dylib || echo so)
+cmd=".L ${MACRO}; setup_rarexsec(\"${LIBDIR}/librarexsec.${libext}\",\"${INCDIR}\");"
+
+# Start ROOT, run setup, then forward any user macro call e.g. '-- -q my.C'
+root -l -q -e "$cmd" "$@"

--- a/scripts/setup_rarexsec.C
+++ b/scripts/setup_rarexsec.C
@@ -1,0 +1,55 @@
+#include <cstring>
+#include <iostream>
+#include <string>
+
+#include "TInterpreter.h"
+#include "TROOT.h"
+#include "TSystem.h"
+
+void load_header(const std::string& h) {
+  TInterpreter::EErrorCode ec;
+  gInterpreter->ProcessLine((std::string("#include <") + h + ">").c_str(), &ec);
+  if (ec != 0) {
+    std::cout << "Error including header <" << h << ">. "
+              << "Ensure your include directory is in ROOT_INCLUDE_PATH.\n";
+  }
+}
+
+void setup_rarexsec(const char* abs_lib_path = nullptr, const char* abs_inc_dir = nullptr) {
+  // Some ROOT 6 builds need libGraf preloaded for dictionaries
+  if (gROOT->GetVersionInt() >= 60000) {
+    if (gSystem->Load("libGraf") != 0) {
+      std::cout << "Warning: could not preload libGraf\n";
+    }
+  }
+
+  // Include dir (optional explicit arg)
+  if (abs_inc_dir && std::strlen(abs_inc_dir) > 0) {
+    gSystem->AddIncludePath((std::string("-I") + abs_inc_dir).c_str());
+  }
+
+  // Load library (absolute path if given, else rely on DYLD/LD_LIBRARY_PATH)
+  int rc = 1;
+  if (abs_lib_path && std::strlen(abs_lib_path) > 0) {
+    rc = gSystem->Load(abs_lib_path);
+  }
+  if (rc != 0) {
+    rc = gSystem->Load("librarexsec"); // fall back to soname
+  }
+
+  if (rc == 0) {
+    std::cout << "Loaded rarexsec library.\n";
+  } else {
+    std::cout << "Error loading rarexsec library. Add its directory to "
+              << (gSystem->UnixPathName("/") ? "LD_LIBRARY_PATH" : "DYLD_LIBRARY_PATH")
+              << " or pass an absolute path to setup_rarexsec().\n";
+  }
+
+  // Pull in commonly used headers so macros can use the API immediately
+  load_header("rarexsec/data/Types.h");
+  load_header("rarexsec/data/SampleSet.h");
+  load_header("rarexsec/data/NuMuCCSelector.h");
+  load_header("rarexsec/data/TruthClassifier.h");
+  load_header("rarexsec/data/MuonSelector.h");
+  load_header("rarexsec/data/Weighter.h");
+}


### PR DESCRIPTION
## Summary
- add the rarexsec-config template along with ROOT setup macro and shell wrapper
- update the build to emit libraries in build/lib, generate the config script, and install helper assets
- build a static lib alongside the shared objects and hook installation for the ROOT dictionary output

## Testing
- make -C build *(fails: missing ROOT headers in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7dd5653c832ea56c22b462a8c00f