### PR TITLE
Add helper scripts and integrate rarexsec config generation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -5,6 +5,18 @@ BUILD_DIR := $(TOP_DIR)/build
 OBJ_DIR := $(BUILD_DIR)/obj
 LIB_DIR := $(BUILD_DIR)/lib
 
+SCRIPTDIR   := $(TOP_DIR)/scripts
+VERSION     ?= $(shell cd $(TOP_DIR) && git describe --tags --always --dirty 2>/dev/null || echo 0.0.0)
+GIT_REV     := $(shell cd $(TOP_DIR) && git rev-parse --short HEAD 2>/dev/null || echo unknown)
+# Extract c++ standard from CXXFLAGS or default:
+CXX_STD_STR ?= $(or $(patsubst -std=%,%,$(filter -std=%,$(CXXFLAGS))),c++17)
+USE_ROOT    ?= yes   # your project uses ROOT; set 'no' if ever optional
+
+CONFIG_IN   := $(SCRIPTDIR)/rarexsec-config.in
+CONFIG_OUT  := $(BUILD_DIR)/bin/rarexsec-config
+ROOT_WRAPPER:= $(SCRIPTDIR)/rarexsec-root.sh
+SETUP_MACRO := $(SCRIPTDIR)/setup_rarexsec.C
+
 PROJECT_SHARED_LIB_NAME := rarexsec
 ROOT_SHARED_LIB_NAME := rarexsec_root
 SHARED_LIB := $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME)
@@ -54,8 +66,10 @@ endif
 ifneq (,$(wildcard $(TOP_DIR)/.VERSION))
   PROJECT_VERSION := $(shell cat $(TOP_DIR)/.VERSION)
 else
-  PROJECT_VERSION := $(GIT_REVISION)
+  PROJECT_VERSION := $(VERSION)
 endif
+
+GIT_REV := $(GIT_REVISION)
 
 ROOTCONFIG := $(shell command -v root-config 2> /dev/null)
 ROOT := $(shell command -v root 2> /dev/null)
@@ -122,6 +136,7 @@ ALL_TARGETS := $(SHARED_LIB).$(SOEXT) $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a
 ifeq ($(USE_ROOT),yes)
   ALL_TARGETS += $(ROOT_SHARED_LIB).$(SOEXT)
 endif
+ALL_TARGETS += $(CONFIG_OUT)
 
 .PHONY: all debug shared static rootlib install run clean distclean print
 
@@ -137,6 +152,17 @@ debug: $(ALL_TARGETS)
 
 $(LIB_DIR) $(OBJ_DIR):
 	@$(MKDIR) $@
+
+$(BUILD_DIR)/bin:
+	@$(MKDIR) $@
+
+$(CONFIG_OUT): $(CONFIG_IN) | $(BUILD_DIR)/bin
+	sed -e 's|@@VERSION@@|$(VERSION)|g' \
+	    -e 's|@@GIT_REVISION@@|$(GIT_REV)|g' \
+	    -e 's|@@CXX_STD@@|$(CXX_STD_STR)|g' \
+	    -e 's|@@USE_ROOT@@|$(USE_ROOT)|g' \
+	    $< > $@
+	chmod +x $@
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cc | $(OBJ_DIR)
 	@$(MKDIR) $(dir $@)
@@ -173,22 +199,27 @@ INSTALL_LIBDIR := $(PREFIX)/lib
 INSTALL_INCDIR := $(PREFIX)/include
 
 install: all
-	@$(MKDIR) $(INSTALL_LIBDIR) $(INSTALL_INCDIR)
+	@$(MKDIR) $(INSTALL_LIBDIR) $(INSTALL_INCDIR) $(PREFIX)/bin $(PREFIX)/scripts
 	@cp -a $(SHARED_LIB).$(SOEXT) $(INSTALL_LIBDIR)/
 	@cp -a $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a $(INSTALL_LIBDIR)/
 ifeq ($(USE_ROOT),yes)
 	@cp -a $(ROOT_SHARED_LIB).$(SOEXT) $(INSTALL_LIBDIR)/
 endif
 	@rsync -a --delete $(INCLUDE_DIR)/ $(INSTALL_INCDIR)/
+	@cp -a $(CONFIG_OUT) $(PREFIX)/bin/
+	@cp -a $(ROOT_WRAPPER) $(PREFIX)/bin/rarexsec-root
+	@cp -a $(SETUP_MACRO) $(PREFIX)/scripts/
 	@echo "Installed to $(PREFIX)"
 	@echo "  - libs:    $(INSTALL_LIBDIR)"
 	@echo "  - headers: $(INSTALL_INCDIR)"
+	@echo "  - scripts: $(PREFIX)/bin"
+	@echo "  - macros:  $(PREFIX)/scripts"
 
 run: $(SHARED_LIB).$(SOEXT)
 	@test -n "$(ROOT)" || (echo "ROOT executable not found" && exit 1)
 	@root -l -q -e 'gSystem->Load("$(abspath $(SHARED_LIB)).$(SOEXT)"); \
-	                 gSystem->AddIncludePath("-I$(abspath $(INCLUDE_DIR))"); \
-	                 gROOT->ProcessLine(".x $(MACRO)$(ARGS)");'
+                         gSystem->AddIncludePath("-I$(abspath $(INCLUDE_DIR))"); \
+                         gROOT->ProcessLine(".x $(SETUP_MACRO)$(ARGS)");'
 
 print:
 	@echo "CXX           = $(CXX)"
@@ -201,7 +232,7 @@ print:
 	@echo "SOEXT         = $(SOEXT)"
 
 clean:
-	$(RMDIR) $(OBJ_DIR) $(LIB_DIR)
+	$(RMDIR) $(OBJ_DIR) $(LIB_DIR) $(BUILD_DIR)/bin
 
 distclean: clean
 	$(RMDIR) $(PREFIX)

--- a/scripts/rarexsec-config.in
+++ b/scripts/rarexsec-config.in
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# rarexsec-config — print compiler/linker flags and paths for rarexsec
+
+# Resolve topdir: prefer RAREXSEC env; else derive from this script location
+if [ -z "$RAREXSEC" ]; then
+  topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+else
+  topdir=${RAREXSEC}
+fi
+
+bindir=${topdir}/build/bin
+datadir=${topdir}/data
+incdir=${topdir}/include
+libdir=${topdir}/build/lib
+srcdir=${topdir}/src
+
+version=@@VERSION@@
+git_rev=@@GIT_REVISION@@
+cxx_std=@@CXX_STD@@
+use_root=@@USE_ROOT@@
+
+root_cflags=""
+root_libs=""
+if [ "$use_root" = "yes" ]; then
+  root_cflags="$(root-config --cflags) -DUSE_ROOT"
+  root_libs="$(root-config --libs)"
+fi
+
+cflags="${root_cflags} -std=${cxx_std} -I${incdir}"
+libs="-L${libdir} -lrarexsec ${root_libs}"
+
+usage="Usage: rarexsec-config [--bindir] [--cflags] [--cxx-std] [--datadir] \
+[--libs] [--libdir] [--incdir] [--srcdir] [--topdir] [--use-root] \
+[--version] [--git-revision] [--help]"
+
+if [ $# -eq 0 ]; then echo "${usage}"; exit 1; fi
+for arg in "$@"; do
+  case $arg in
+    --help) echo "${usage}"; exit 0;;
+    --cflags)        out="$out $cflags" ;;
+    --cxx-std)       out="$out $cxx_std" ;;
+    --bindir)        out="$out $bindir" ;;
+    --datadir)       out="$out $datadir" ;;
+    --libs)          out="$out $libs" ;;
+    --libdir)        out="$out $libdir" ;;
+    --incdir)        out="$out $incdir" ;;
+    --srcdir)        out="$out $srcdir" ;;
+    --topdir)        out="$out $topdir" ;;
+    --use-root)      out="$out $use_root" ;;
+    --version)       out="$out $version" ;;
+    --git-revision)  out="$out $git_rev" ;;
+    *) echo "Unknown arg: $arg"; echo "${usage}"; exit 3;;
+  esac
+done
+echo $out

--- a/scripts/rarexsec-root.sh
+++ b/scripts/rarexsec-root.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+# Determine topdir from RAREXSEC or script path
+if [ -z "$RAREXSEC" ]; then
+  TOPDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+else
+  TOPDIR="$RAREXSEC"
+fi
+LIBDIR="${TOPDIR}/build/lib"
+INCDIR="${TOPDIR}/include"
+MACRO="${TOPDIR}/scripts/setup_rarexsec.C"
+
+# Ensure library path and includes are visible to ROOT
+case "$(uname -s)" in
+  Darwin) export DYLD_LIBRARY_PATH="${LIBDIR}:${DYLD_LIBRARY_PATH}" ;;
+  *)      export LD_LIBRARY_PATH="${LIBDIR}:${LD_LIBRARY_PATH}" ;;
+esac
+export ROOT_INCLUDE_PATH="${INCDIR}:${ROOT_INCLUDE_PATH}"
+
+# Start ROOT, run setup, then forward any user macro call e.g. '-- -q my.C'
+root -l -q -e "setup_rarexsec(\"${LIBDIR}/librarexsec.$( [ \"$(uname -s)\" = Darwin ] && echo dylib || echo so )\",\"${INCDIR}\");" "$@"

--- a/scripts/setup_rarexsec.C
+++ b/scripts/setup_rarexsec.C
@@ -1,0 +1,56 @@
+// scripts/setup_rarexsec.C
+#include <cstring>
+#include <iostream>
+#include <string>
+
+#include "TInterpreter.h"
+#include "TROOT.h"
+#include "TSystem.h"
+void load_header(const std::string& h) {
+  TInterpreter::EErrorCode ec;
+  gInterpreter->ProcessLine( (std::string("#include <") + h + ">").c_str(), &ec );
+  if (ec != 0) {
+    std::cout << "Error including header <" << h << ">. "
+              << "Ensure your include directory is in ROOT_INCLUDE_PATH.\n";
+  }
+}
+
+void setup_rarexsec(const char* abs_lib_path = nullptr, const char* abs_inc_dir = nullptr) {
+  // Some ROOT 6 builds need libGraf preloaded for dictionaries
+  if (gROOT->GetVersionInt() >= 60000) {
+    if (gSystem->Load("libGraf") != 0) {
+      std::cout << "Warning: could not preload libGraf\n";
+    }
+  }
+
+  // Include dir (optional explicit arg)
+  if (abs_inc_dir && std::strlen(abs_inc_dir) > 0) {
+    gSystem->AddIncludePath( (std::string("-I") + abs_inc_dir).c_str() );
+  }
+
+  // Load library (absolute path if given, else rely on DYLD/LD_LIBRARY_PATH)
+  int rc = 1;
+  if (abs_lib_path && std::strlen(abs_lib_path) > 0) {
+    rc = gSystem->Load(abs_lib_path);
+  }
+  if (rc != 0) {
+    rc = gSystem->Load("librarexsec"); // fall back to soname
+  }
+
+  if (rc == 0) {
+    std::cout << "Loaded rarexsec library.\n";
+  } else {
+    const char* env_var = gSystem->UnixPathName("/") ? "LD_LIBRARY_PATH" : "DYLD_LIBRARY_PATH";
+    std::cout << "Error loading rarexsec library. Add its directory to "
+              << env_var
+              << " or pass an absolute path to setup_rarexsec().\n";
+  }
+
+  // Pull in commonly used headers so macros can use the API immediately
+  load_header("rarexsec/data/Types.h");
+  load_header("rarexsec/data/SampleSet.h");
+  load_header("rarexsec/data/NuMuCCSelector.h");
+  load_header("rarexsec/data/TruthClassifier.h");
+  load_header("rarexsec/data/MuonSelector.h");
+  load_header("rarexsec/data/Weighter.h");
+}


### PR DESCRIPTION
## Summary
- add scripts for generating rarexsec configuration, loading the library in ROOT, and preloading headers
- update the build to emit the rarexsec-config helper, install the new scripts, and clean generated artifacts

## Testing
- make -C build print

------
https://chatgpt.com/codex/tasks/task_e_68da834a8d44832ebef560ed2f84f927