### PR TITLE
Add automatic discovery of nlohmann/json headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Before building, ensure the following tools are available on your system:
 - A C++17-capable compiler such as GCC or Clang.
 - [ROOT 6](https://root.cern/) with the `root-config`, `rootcling` (or
   `rootcint`), and `root` executables on your `PATH`.
+- The [nlohmann/json](https://github.com/nlohmann/json) single-header
+  library.  Many ROOT builds, including those distributed through CVMFS,
+  already provide it.  If it is installed in a non-standard location, set the
+  `NLOHMANN_JSON_INC` environment variable (or make variable) to the directory
+  that contains the `nlohmann/json.hpp` header so the build system can locate
+  it.
 - Standard development utilities: `make`, `bash`, and `git`.
 
 You can quickly check that ROOT is discoverable with `root-config --version`.

--- a/build/Makefile
+++ b/build/Makefile
@@ -78,6 +78,7 @@ ifndef ROOTCLING
   ROOTCLING := $(shell command -v rootcint 2> /dev/null)
 endif
 
+ROOT_PREFIX :=
 ifeq ($(ROOTCONFIG),)
   $(warning ROOT not found. Dictionary library will not be built.)
   USE_ROOT := no
@@ -88,6 +89,7 @@ else
   ROOT_VERSION := $(shell $(ROOTCONFIG) --version)
   $(info Found ROOT version $(ROOT_VERSION) in $(ROOT))
   USE_ROOT := yes
+  ROOT_PREFIX := $(shell $(ROOTCONFIG) --prefix)
   ROOT_CXXFLAGS := $(shell $(ROOTCONFIG) --cflags)
   ROOT_LDFLAGS := $(shell $(ROOTCONFIG) --ldflags)
   ROOT_LIBS := $(shell $(ROOTCONFIG) --libs)
@@ -97,6 +99,22 @@ EXTRA_INC ?=
 EXTRA_CXXFLAGS ?=
 EXTRA_LDFLAGS ?=
 EXTRA_LIBS ?=
+
+NLOHMANN_JSON_INC ?=
+ifeq ($(strip $(NLOHMANN_JSON_INC)),)
+  ROOT_BIN_INCLUDE := $(if $(ROOTCONFIG),$(abspath $(dir $(ROOTCONFIG))../include))
+  NLOHMANN_JSON_SEARCH_DIRS := \
+    $(if $(ROOT_PREFIX),$(ROOT_PREFIX)/include) \
+    $(ROOT_BIN_INCLUDE) \
+    /usr/include \
+    /usr/local/include
+  NLOHMANN_JSON_HEADER := $(firstword $(foreach d,$(filter-out ,$(NLOHMANN_JSON_SEARCH_DIRS)),$(wildcard $(d)/nlohmann/json.hpp)))
+  ifneq ($(NLOHMANN_JSON_HEADER),)
+    EXTRA_INC += -I$(patsubst %/nlohmann/json.hpp,%,$(NLOHMANN_JSON_HEADER))
+  endif
+else
+  EXTRA_INC += -I$(strip $(NLOHMANN_JSON_INC))
+endif
 
 OPTFLAGS := -O3
 ifeq ($(MAKECMDGOALS),debug)


### PR DESCRIPTION
## Summary
- update the build system to probe common locations (including the ROOT prefix) for the nlohmann/json header and allow overriding the include path via `NLOHMANN_JSON_INC`
- document the external nlohmann/json dependency and how to point the build to a custom installation

## Testing
- make *(fails: ROOT/RVec.hxx missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da8bbd0690832e80cecd99c7b14493