### PR TITLE
Fix rootcling include search path

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -202,7 +202,7 @@ ifeq ($(USE_ROOT),yes)
 $(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h $(ROOT_DICT_HEADERS) | $(OBJ_DIR)
 	@$(MKDIR) $(dir $@)
 	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
-	$(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) \
+    $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) $(ROOT_CXXFLAGS) $(EXTRA_INC) $(EXTRA_CXXFLAGS) \
 	$(ROOT_DICT_HEADERS_REL) \
 	$(SRC_DIR)/rarexsecLinkDef.h
 	$(CXX) $(CXXFLAGS) -MMD -MP -c $(ROOT_DICT_SRC) -o $@


### PR DESCRIPTION
## Summary
- ensure the rootcling dictionary generation receives the same include and compiler flags as the normal build

## Testing
- make *(fails: ROOT not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da8d5a58a4832ea2725733b609b74f