### PR TITLE
Remove deprecated WeightProcessor alias

### DIFF
--- a/include/rarexsec/Weighter.h
+++ b/include/rarexsec/Weighter.h
@@ -72,9 +72,6 @@ private:
   long   total_run_triggers_;
 };
 
-// ---------- Backward-compat (remove when migrated) ----------
-using WeightProcessor = Weighter;
-
 } // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- remove the obsolete WeightProcessor type alias from the weighter header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da9a431050832e9e8c291d0e9fec3d