### PR TITLE
Remove legacy WeightProcessor alias

### DIFF
--- a/include/faint/Weighter.h
+++ b/include/faint/Weighter.h
@@ -72,9 +72,6 @@ private:
   long   total_run_triggers_;
 };
 
-// ---------- Backward-compat (remove when migrated) ----------
-using WeightProcessor = Weighter;
-
 } // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- remove the obsolete WeightProcessor alias from the Weighter header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9b453d94832e8afb3193f5b827b1