### PR TITLE
Fix TruthClassifier fiducial volume Define lambda

### DIFF
--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -69,7 +69,7 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
 ROOT::RDF::RNode TruthClassifier::defineCounts(ROOT::RDF::RNode df) const {
   auto fid_df = df.Define(
       "in_fiducial",
-      [](const auto &x, const auto &y, const auto &z) {
+      [](double x, double y, double z) {
         return fiducial::is_in_truth_volume(x, y, z);
       },
       {"neutrino_vertex_x", "neutrino_vertex_y", "neutrino_vertex_z"});


### PR DESCRIPTION
## Summary
- replace the generic lambda used to compute the fiducial volume flag with one that takes concrete doubles so ROOT can infer the return type

## Testing
- make -C build *(fails: ROOT headers are unavailable in this container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da9d2222c0832ea4764892eb0318fe