### PR TITLE
Refactor header structure for FAINT analysis components

### DIFF
--- a/include/faint/Campaign.h
+++ b/include/faint/Campaign.h
@@ -12,11 +12,11 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TSystem.h"
 
-#include <faint/Types.h>
-#include <faint/Variables.h>
-#include <faint/data/RunCatalog.h>
-#include <faint/data/Sample.h>
-#include <faint/data/SampleSet.h>
+#include "faint/Sample.h"
+#include "faint/SampleSet.h"
+#include "faint/Types.h"
+#include "faint/Variables.h"
+#include "faint/RunCatalog.h"
 
 namespace faint {
 namespace campaign {

--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -5,14 +5,13 @@
 
 #include "ROOT/RDataFrame.hxx"
 
-#include <faint/core/AnalysisKey.h>
-#include <faint/data/SampleTypes.h>
+#include "faint/Types.h"
 
 namespace faint {
 
 struct Dataset {
     SampleOrigin origin_;
-    AnalysisRole role_;
+    Role role_;
     mutable ROOT::RDF::RNode dataframe_;
 };
 

--- a/include/faint/EventProcessor.h
+++ b/include/faint/EventProcessor.h
@@ -5,7 +5,7 @@
 
 #include "ROOT/RDataFrame.hxx"
 
-#include <faint/Types.h>
+#include "faint/Types.h"
 
 namespace faint {
 

--- a/include/faint/Logger.h
+++ b/include/faint/Logger.h
@@ -1,0 +1,55 @@
+#ifndef FAINT_LOGGER_H
+#define FAINT_LOGGER_H
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace faint {
+namespace log {
+namespace detail {
+inline void append_to_stream(std::ostream&) {}
+
+template <typename T, typename... Rest>
+void append_to_stream(std::ostream& os, T&& value, Rest&&... rest) {
+  os << std::forward<T>(value);
+  if constexpr (sizeof...(rest) > 0) {
+    os << ' ';
+    append_to_stream(os, std::forward<Rest>(rest)...);
+  }
+}
+
+template <typename... Args>
+std::string build_message(Args&&... args) {
+  std::ostringstream ss;
+  append_to_stream(ss, std::forward<Args>(args)...);
+  return ss.str();
+}
+}  // namespace detail
+
+template <typename... Args>
+void debug(Args&&... args) {
+  std::clog << "[DEBUG] " << detail::build_message(std::forward<Args>(args)...) << std::endl;
+}
+
+template <typename... Args>
+void info(Args&&... args) {
+  std::clog << "[INFO] " << detail::build_message(std::forward<Args>(args)...) << std::endl;
+}
+
+template <typename... Args>
+void warn(Args&&... args) {
+  std::clog << "[WARN] " << detail::build_message(std::forward<Args>(args)...) << std::endl;
+}
+
+template <typename... Args>
+[[noreturn]] void fatal(Args&&... args) {
+  throw std::runtime_error(detail::build_message(std::forward<Args>(args)...));
+}
+
+}  // namespace log
+}  // namespace faint
+
+#endif  // FAINT_LOGGER_H

--- a/include/faint/MuonSelector.h
+++ b/include/faint/MuonSelector.h
@@ -5,7 +5,7 @@
 
 #include "ROOT/RVec.hxx"
 
-#include <faint/EventProcessor.h>
+#include "faint/EventProcessor.h"
 
 namespace faint {
 

--- a/include/faint/PreSelection.h
+++ b/include/faint/PreSelection.h
@@ -3,8 +3,8 @@
 
 #include "ROOT/RVec.hxx"
 
-#include <faint/EventProcessor.h>
-#include <faint/Types.h>
+#include "faint/EventProcessor.h"
+#include "faint/Types.h"
 
 namespace faint {
 

--- a/include/faint/Run.h
+++ b/include/faint/Run.h
@@ -5,10 +5,10 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
+#include "nlohmann/json.hpp"
 
-#include <faint/utils/Logger.h>
-#include <faint/data/SampleDefinition.h>
+#include "faint/Logger.h"
+#include "faint/Sample.h"
 
 namespace faint {
 
@@ -26,15 +26,17 @@ struct Run {
     Run(const json &j, std::string bm, std::string pr)
         : beam_mode(std::move(bm)),
           run_period(std::move(pr)),
-            nominal_pot(j.value("nominal_pot",
-                        j.value("pot_target_wcut_total",
-                        j.value("torb_target_pot_wcut", 0.0)))),
+          nominal_pot(j.value("nominal_pot",
+                              j.value("pot_target_wcut_total",
+                                       j.value("torb_target_pot_wcut", 0.0)))),
           nominal_triggers(j.value("nominal_triggers",
-                           j.value("ext_triggers_total",
-                           j.value("ext_triggers", 0L)))),
+                                   j.value("ext_triggers_total",
+                                            j.value("ext_triggers", 0L)))),
           samples(j.at("samples")) {}
 
     std::string key() const { return beam_mode + ":" + run_period; }
+
+    std::string label() const { return key(); }
 
     void validate() const {
         if (beam_mode.empty()) log::fatal("Run::validate", "empty beam_mode");

--- a/include/faint/RunCatalog.h
+++ b/include/faint/RunCatalog.h
@@ -1,0 +1,41 @@
+#ifndef FAINT_RUN_CATALOG_H
+#define FAINT_RUN_CATALOG_H
+
+#include <map>
+#include <string>
+#include <utility>
+
+#include "nlohmann/json.hpp"
+
+#include "faint/Run.h"
+#include "faint/RunReader.h"
+
+namespace faint {
+
+class RunCatalog {
+ public:
+  RunCatalog() = default;
+
+  explicit RunCatalog(RunReader reader) : reader_(std::move(reader)) {}
+
+  const Run& get(const std::string& beam, const std::string& period) const {
+    return reader_.get(beam, period);
+  }
+
+  const std::map<std::string, Run>& all() const noexcept { return reader_.all(); }
+
+  static RunCatalog fromJson(const nlohmann::json& data) {
+    return RunCatalog{RunReader::read(data)};
+  }
+
+  static RunCatalog fromFile(const std::string& path) {
+    return RunCatalog{RunReader::read(path)};
+  }
+
+ private:
+  RunReader reader_;
+};
+
+}  // namespace faint
+
+#endif

--- a/include/faint/RunReader.h
+++ b/include/faint/RunReader.h
@@ -8,8 +8,8 @@
 
 #include "nlohmann/json.hpp"
 
-#include <faint/utils/Logger.h>
-#include <faint/data/Run.h>  
+#include "faint/Logger.h"
+#include "faint/Run.h"
 
 namespace faint {
 

--- a/include/faint/SampleSet.h
+++ b/include/faint/SampleSet.h
@@ -5,167 +5,164 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "ROOT/RDataFrame.hxx"
 
-#include <faint/core/AnalysisKey.h>
-#include <faint/data/BlipProcessor.h>
-#include <faint/data/IEventProcessor.h>
-#include <faint/utils/Logger.h>
-#include <faint/data/MuonSelectionProcessor.h>
-#include <faint/data/NuMuCCSelectionProcessor.h>
-#include <faint/data/PreselectionProcessor.h>
-#include <faint/data/ReconstructionProcessor.h>
-#include <faint/data/RunCatalog.h>
-#include <faint/data/Samples.h>
-#include <faint/core/SelectionQuery.h>
-#include <faint/data/TruthChannelProcessor.h>
-#include <faint/data/VariableRegistry.h>
-#include <faint/data/WeightProcessor.h>
+#include "faint/EventProcessor.h"
+#include "faint/Logger.h"
+#include "faint/MuonSelector.h"
+#include "faint/PreSelection.h"
+#include "faint/Run.h"
+#include "faint/RunCatalog.h"
+#include "faint/Sample.h"
+#include "faint/TruthClassifier.h"
+#include "faint/Variables.h"
+#include "faint/Weighter.h"
 
 namespace faint {
 
 class SampleSet {
-  public:
-    using Map = std::map<SampleKey, Samples>;
+ public:
+  using Map = std::map<SampleKey, Sample>;
 
-    SampleSet(const RunCatalog &runs, 
-              VariableRegistry variables,
-              const std::string &beam,
-              std::vector<std::string> periods,
-              const std::string &ntuple_dir, 
-              bool blind = true)
-        : runs_(runs),
-          variables_(std::move(variables)),
-          ntuple_dir_(ntuple_dir),
-          beam_(beam),
-          periods_(std::move(periods)),
-          blind_(blind),
-          total_pot_(0.0),
-          total_triggers_(0) {
-        this->();
+  SampleSet(const RunCatalog& runs,
+            VariableRegistry variables,
+            std::string beam,
+            std::vector<std::string> periods,
+            std::string ntuple_dir,
+            bool blind = true)
+      : runs_(runs),
+        variables_(std::move(variables)),
+        ntuple_dir_(std::move(ntuple_dir)),
+        beam_(std::move(beam)),
+        periods_(std::move(periods)),
+        blind_(blind) {
+    build();
+  }
+
+  Map& frames() noexcept { return samples_; }
+  const Map& frames() const noexcept { return samples_; }
+
+  double total_pot() const noexcept { return total_pot_; }
+  long total_triggers() const noexcept { return total_triggers_; }
+
+  const std::string& beam() const noexcept { return beam_; }
+  const std::vector<std::string>& periods() const noexcept { return periods_; }
+
+  const Run* run_for(const SampleKey& key) const {
+    auto it = run_cache_.find(key);
+    return it != run_cache_.end() ? it->second : nullptr;
+  }
+
+  void snapshot(const std::string& filter,
+                const std::string& out,
+                const std::vector<std::string>& columns = {}) const {
+    bool first = true;
+    ROOT::RDF::RSnapshotOptions opts;
+    for (const auto& [key, sample] : samples_) {
+      auto node = sample.node_;
+      if (!filter.empty()) {
+        node = node.Filter(filter);
+      }
+      opts.fMode = first ? "RECREATE" : "UPDATE";
+      node.Snapshot(key.str().c_str(), out, columns, opts);
+      first = false;
     }
+  }
 
-    Map &frames() noexcept { return samples_; }
+  void snapshot_final(const std::string& out,
+                      const std::vector<std::string>& columns = {}) const {
+    snapshot("pass_final", out, columns);
+  }
 
-    double total_pot() const noexcept { return total_pot_; }
-
-    long total_triggers() const noexcept { return total_triggers_; }
-
-    const std::string &beam() const noexcept { return beam_; }
-
-    const std::vector<std::string> &periods() const noexcept { return periods_; }
-
-    const Run* run_for(const SampleKey &sk) const {
-        auto it = run_cache_.find(sk);
-        if (it != run_cache_.end()) ? it->second : nullptr;
+  void print_branches() const {
+    log::debug("SampleSet::print_branches", "Available branches in loaded samples:");
+    for (const auto& [sample_key, sample] : samples_) {
+      log::debug("SampleSet::print_branches", "--- Sample:", sample_key.str(), "---");
+      auto branches = sample.node_.GetColumnNames();
+      for (const auto& branch : branches) {
+        log::debug("SampleSet::print_branches", "  - ", branch);
+      }
     }
+  }
 
-    void snapshot(const std::string &filter, 
-                  const std::string &out,
-                  const std::vector<std::string> &cols = {}) const {
-        bool first = true;
-        ROOT::RDF::RSnapshotOptions opts;
-        for (auto const &[key, sample] : samples_) {
-            auto df = sample.nominal_node_;
-            if (!filter.empty()) df = df.Filter(filter);
-            opts.fMode = first ? "RECREATE" : "UPDATE";
-            df.Snapshot(key.c_str(), out, cols, opts);
-            first = false;
+ private:
+  const RunCatalog& runs_;
+  VariableRegistry variables_;
+  std::string ntuple_dir_;
+  std::string beam_;
+  std::vector<std::string> periods_;
+  bool blind_;
+
+  double total_pot_{0.0};
+  long total_triggers_{0};
+
+  Map samples_;
+  std::vector<std::unique_ptr<EventProcessor>> processors_;
+  std::unordered_map<SampleKey, const Run*> run_cache_;
+
+  void build() {
+    for (const auto& period : periods_) {
+      const Run& run = runs_.get(beam_, period);
+      add_run(run);
+
+      auto ext_beam = infer_external_beam(beam_);
+      if (!ext_beam.empty()) {
+        auto key = ext_beam + ":" + period;
+        if (runs_.all().count(key)) {
+          add_run(runs_.get(ext_beam, period));
         }
+      }
     }
+  }
 
-    void snapshot(const SelectionQuery &query, 
-                  const std::string &out,
-                  const std::vector<std::string> &cols = {}) const {
-        this->snapshot(query.str(), out, cols);
+  static std::string infer_external_beam(const std::string& beam) {
+    auto dash = beam.find('-');
+    if (dash == std::string::npos) {
+      return beam + "-ext";
     }
+    return beam.substr(0, dash) + "-ext";
+  }
 
-    void print_branches() {
-        log::debug("SampleSet::print_branches", "Available branches in loaded samples:");
-        for (auto &[sample_key, sample_def] : samples_) {
-            log::debug("SampleSet::print_branches", "--- Sample:", sample_key.str(), "---");
-            auto branches = sample_def.nominal_node_.GetColumnNames();
-            for (const auto &branch : branches) {
-                log::debug("SampleSet::print_branches", "  - ", branch);
-            }
-        }
+  void add_run(const Run& run) {
+    total_pot_ += run.nominal_pot;
+    total_triggers_ += run.nominal_triggers;
+
+    processors_.reserve(processors_.size() + run.samples.size());
+    for (const auto& sample_json : run.samples) {
+      if (sample_json.contains("active") && !sample_json.at("active").get<bool>()) {
+        log::info("SampleSet::add_run", "Skipping inactive sample:", sample_json.at("sample_key").get<std::string>());
+        continue;
+      }
+
+      auto pipeline = chain(std::make_unique<Weighter>(sample_json, total_pot_, total_triggers_),
+                            std::make_unique<PreSelection>(),
+                            std::make_unique<MuonSelector>(),
+                            std::make_unique<TruthClassifier>());
+
+      processors_.push_back(std::move(pipeline));
+      auto& processor = *processors_.back();
+
+      Sample sample{sample_json, run.samples, ntuple_dir_, variables_, processor};
+      run_cache_.emplace(sample.key_, &run);
+      samples_.emplace(sample.key_, std::move(sample));
     }
+  }
 
-  private:
-    const RunCatalog &runs_;
-    VariableRegistry variables_;
-    std::string ntuple_dir_;
-
-    std::string beam_;
-    std::vector<std::string> periods_;
-    bool blind_;
-
-    double total_pot_;
-    long total_triggers_;
-
-    Map samples_;
-    std::vector<std::unique_ptr<IEventProcessor>> processors_;
-    std::unordered_map<SampleKey, const Run* > run_cache_;
-
-    void build() {
-        const std::string ext_beam{"numi_ext"}; // this is wrong, change this!
-        std::vector<const Run*> to_process;
-
-        for (auto &p : periods_) {
-            const auto &rc = runs_.get(beam_, p);
-            total_pot_ += rc.nominal_pot;
-            total_triggers_ += rc.nominal_triggers;
-            to_process.push_back(&rc);
-
-            auto key = ext_beam + ":" + p;
-            if (runs_.all().count(key)) {
-                const auto &er = runs_.get(ext_beam, p);
-                total_pot_ += er.nominal_pot;
-                total_triggers_ += er.nominal_triggers;
-                to_process.push_back(&er);
-            }
-        }
-
-        for (const Run* rc : to_process) this->add_run(*rc);
+  template <typename Head, typename... Tail>
+  std::unique_ptr<EventProcessor> chain(std::unique_ptr<Head> head, std::unique_ptr<Tail>... tail) {
+    if constexpr (sizeof...(tail) == 0) {
+      return head;
+    } else {
+      auto next = chain(std::move(tail)...);
+      head->chain_processor(std::move(next));
+      return head;
     }
-
-    void add_run(const Run& rc) {
-        processors_.reserve(processors_.size() + rc.samples.size());
-        for (auto &s : rc.samples) {
-            if (s.contains("active") && !s.at("active").get<bool>()) {
-                log::info("SampleSet::add_run", "Skipping inactive sample: ", s.at("sample_key").get<std::string>());
-                continue;
-            }
-
-            auto pipeline = this->chain(
-                std::make_unique<Weighter>(s, total_pot_, total_triggers_),
-                std::make_unique<PreSelection>(),
-                std::make_unique<MuonSelector>(),
-                std::make_unique<TruthClassifier>(),
-            processors_.push_back(std::move(pipeline));
-
-            auto &proc = *processors_.back();
-            Samples sample{s, rc.samples, ntuple_dir_, variables_, proc};
-
-            run_cache_.emplace(sample.sample_key_, &rc);
-            samples_.emplace(sample.sample_key_, std::move(sample));
-        }
-    }
-
-    template <typename Head, typename... Tail>
-    std::unique_ptr<IEventProcessor> chain(std::unique_ptr<Head> head, std::unique_ptr<Tail>... tail) {
-        if constexpr (sizeof...(tail) == 0) {
-            return head;
-        } else {
-            auto next = this->chain(std::move(tail)...);
-            head->chain_next(std::move(next));
-            return head;
-        }
-    }
+  }
 };
 
-}
+}  // namespace faint
 
 #endif

--- a/include/faint/TruthClassifier.h
+++ b/include/faint/TruthClassifier.h
@@ -6,7 +6,7 @@
 #include <map>
 #include <mutex>
 
-#include <faint/EventProcessor.h>
+#include "faint/EventProcessor.h"
 
 namespace faint {
 

--- a/include/faint/Types.h
+++ b/include/faint/Types.h
@@ -1,6 +1,7 @@
 #ifndef ANALYSIS_TYPES_H
 #define ANALYSIS_TYPES_H
 
+#include <functional>
 #include <string>
 
 namespace faint {
@@ -22,6 +23,30 @@ enum class Variation : unsigned int {
     kWireModAngleYZ
 };
 
+using SampleOrigin = Origin;
+using SampleVariation = Variation;
+
+class SampleKey {
+  public:
+    SampleKey() = default;
+    explicit SampleKey(std::string key) : key_(std::move(key)) {}
+
+    const std::string &str() const noexcept { return key_; }
+
+    bool empty() const noexcept { return key_.empty(); }
+
+    friend bool operator==(const SampleKey &lhs, const SampleKey &rhs) noexcept {
+        return lhs.key_ == rhs.key_;
+    }
+
+    friend bool operator<(const SampleKey &lhs, const SampleKey &rhs) noexcept {
+        return lhs.key_ < rhs.key_;
+    }
+
+  private:
+    std::string key_;
+};
+
 inline std::string to_key(Variation var) {
     switch (var) {
         case Variation::kCV:              return "CV";
@@ -38,6 +63,15 @@ inline std::string to_key(Variation var) {
     }
 }
 
-} 
+}
+
+namespace std {
+template <>
+struct hash<faint::SampleKey> {
+    std::size_t operator()(const faint::SampleKey &key) const noexcept {
+        return std::hash<std::string>{}(key.str());
+    }
+};
+}
 
 #endif

--- a/include/faint/Variables.h
+++ b/include/faint/Variables.h
@@ -6,7 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <faint/data/Types.h>
+#include "faint/Types.h"
 
 namespace faint {
 
@@ -55,14 +55,14 @@ public:
 
 private:
   static std::unordered_set<std::string> collect_base_vars() {
-    std::unordered_set<std::string> vars{().begin(), ().end()};
-    vars.insert(reco_var().begin(),  reco_var().end());
-    vars.insert(track_var().begin(),  track_var().end());
+    std::unordered_set<std::string> vars(base_var().begin(), base_var().end());
+    vars.insert(reco_var().begin(), reco_var().end());
+    vars.insert(track_var().begin(), track_var().end());
     vars.insert(proc_evt_var().begin(), proc_evt_var().end());
-    vars.insert(image_var().begin(),     image_var().end());
-    vars.insert(flash_var().begin(),     flash_var().end());
-    vars.insert(energy_var().begin(),    energy_var().end());
-    vars.insert(slice_var().begin(),     slice_var().end());
+    vars.insert(image_var().begin(), image_var().end());
+    vars.insert(flash_var().begin(), flash_var().end());
+    vars.insert(energy_var().begin(), energy_var().end());
+    vars.insert(slice_var().begin(), slice_var().end());
     return vars;
   }
 

--- a/include/faint/Weighter.h
+++ b/include/faint/Weighter.h
@@ -2,11 +2,12 @@
 #define ANALYSIS_WEIGHTER_H
 
 #include <cmath>
-#include <nlohmann/json.hpp>
 
-#include <faint/utils/Logger.h>
-#include <faint/data/EventProcessor.h>
-#include <faint/data/Types.h>
+#include "nlohmann/json.hpp"
+
+#include "faint/EventProcessor.h"
+#include "faint/Logger.h"
+#include "faint/Types.h"
 
 namespace faint {
 


### PR DESCRIPTION
## Summary
- add a lightweight logging helper and a `RunCatalog` wrapper to manage run metadata access
- refactor `Sample`, `SampleSet`, and type definitions to use consistent FAINT headers instead of stale include paths
- update `Campaign`, `Variables`, `Weighter`, and related headers to integrate with the new infrastructure

## Testing
- `make -C build -j4` *(fails: ROOT headers are not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da9fddba80832e8cccce8595ba2729