### PR TITLE
Refactor FAINT headers to be declarative

### DIFF
--- a/include/faint/Campaign.h
+++ b/include/faint/Campaign.h
@@ -62,17 +62,17 @@ public:
 
     void snapshot_final(const std::string& out_file, const std::vector<std::string>& columns = {}) const;
 
-    double pot() const noexcept { return set().total_pot(); }
+    double pot() const noexcept;
 
-    long triggers() const noexcept { return set().total_triggers(); }
+    long triggers() const noexcept;
 
-    const std::string& beam() const noexcept { return opt_.beam; }
+    const std::string& beam() const noexcept;
 
-    const std::vector<std::string>& periods() const noexcept { return opt_.periods; }
+    const std::vector<std::string>& periods() const noexcept;
 
-    const SampleSet& samples() const { return set(); }
+    const SampleSet& samples() const;
 
-    const RunCatalog& runs() const { return runs_; }
+    const RunCatalog& runs() const;
 
 private:
     RunCatalog runs_;
@@ -80,7 +80,7 @@ private:
     Options opt_;
     std::unique_ptr<SampleSet> set_;
 
-    const SampleSet& set() const { return *set_; }
+    const SampleSet& set() const;
 
     const Sample* find_sample(std::string_view key) const;
 };

--- a/include/faint/EventProcessor.h
+++ b/include/faint/EventProcessor.h
@@ -15,7 +15,7 @@ public:
 
   virtual ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const = 0;
 
-  void chain_processor(std::unique_ptr<EventProcessor> next) { next_ = std::move(next); }
+  void chain_processor(std::unique_ptr<EventProcessor> next);
 
 protected:
   std::unique_ptr<EventProcessor> next_;

--- a/include/faint/Run.h
+++ b/include/faint/Run.h
@@ -1,14 +1,9 @@
 #ifndef RUN_CONFIG_H
 #define RUN_CONFIG_H
 
-#include <set>
 #include <string>
-#include <vector>
 
 #include <nlohmann/json.hpp>
-
-#include <faint/utils/Logger.h>
-#include <faint/data/SampleDefinition.h>
 
 namespace faint {
 
@@ -23,30 +18,12 @@ struct Run {
 
     json samples;
 
-    Run(const json &j, std::string bm, std::string pr)
-        : beam_mode(std::move(bm)),
-          run_period(std::move(pr)),
-            nominal_pot(j.value("nominal_pot",
-                        j.value("pot_target_wcut_total",
-                        j.value("torb_target_pot_wcut", 0.0)))),
-          nominal_triggers(j.value("nominal_triggers",
-                           j.value("ext_triggers_total",
-                           j.value("ext_triggers", 0L)))),
-          samples(j.at("samples")) {}
+    Run(const json& j, std::string bm, std::string pr);
 
-    std::string key() const { return beam_mode + ":" + run_period; }
+    std::string key() const;
+    std::string label() const;
 
-    void validate() const {
-        if (beam_mode.empty()) log::fatal("Run::validate", "empty beam_mode");
-        if (run_period.empty()) log::fatal("Run::validate", "empty run_period");
-        if (samples.empty()) log::fatal("Run::validate", "no samples for", beam_mode + "/" + run_period);
-
-        std::set<std::string> keys;
-        for (auto &s : samples) {
-            std::string key = s.at("sample_key").get<std::string>();
-            if (!keys.insert(key).second) log::fatal("Run::validate", "duplicate sample key:", key);
-        }
-    }
+    void validate() const;
 };
 
 }

--- a/include/faint/RunReader.h
+++ b/include/faint/RunReader.h
@@ -2,61 +2,25 @@
 #define FAINT_RUN_READER_H
 
 #include <map>
-#include <fstream>
-#include <stdexcept>
 #include <string>
 
 #include "nlohmann/json.hpp"
 
-#include <faint/utils/Logger.h>
-#include <faint/data/Run.h>  
+#include <faint/Run.h>
 
 namespace faint {
 
 class RunReader {
 public:
-  void add(Run rc) {
-    auto key = rc.label();
-    if (configs_.count(key))
-      throw std::runtime_error("Duplicate Run label: " + key);
-    configs_.emplace(std::move(key), std::move(rc));
-  }
+  void add(Run rc);
 
-  const Run& get(const std::string& beam, const std::string& period) const {
-    auto key = beam + ":" + period;
-    auto it = configs_.find(key);
-    if (it == configs_.end())
-      throw std::out_of_range("Run not found: " + key);
-    return it->second;
-  }
+  const Run& get(const std::string& beam, const std::string& period) const;
 
-  const std::map<std::string, Run>& all() const noexcept { return configs_; }
+  const std::map<std::string, Run>& all() const noexcept;
 
-  static RunReader read(const nlohmann::json& data) {
-    RunReader out;
-    const std::string top = data.contains("run_configurations") ? "run_configurations" : "beamlines";
-    for (auto const& [beam, runs] : data.at(top).items()) {
-      for (auto const& [period, details] : runs.items()) {
-        Run rc(details, beam, period);  
-        rc.validate();
-        out.add(std::move(rc));
-      }
-    }
-    return out;
-  }
+  static RunReader read(const nlohmann::json& data);
 
-  static RunReader read(const std::string& path) {
-    std::ifstream f(path);
-    if (!f.is_open())
-      log::fatal("RunReader::read", "Could not open config file:", path);
-    try {
-      nlohmann::json data = nlohmann::json::parse(f);
-      return read(data);
-    } catch (const std::exception& e) {
-      log::fatal("RunReader::read", "Parsing error:", e.what());
-    }
-    return {}; 
-  }
+  static RunReader read(const std::string& path);
 
 private:
   std::map<std::string, Run> configs_;

--- a/include/faint/Sample.h
+++ b/include/faint/Sample.h
@@ -9,144 +9,42 @@
 #include "ROOT/RDataFrame.hxx"
 #include "nlohmann/json.hpp"
 
-#include <faint/utils/Logger.h>
 #include <faint/data/IEventProcessor.h>
 #include <faint/data/SampleTypes.h>
 #include <faint/data/VariableRegistry.h>
 
 namespace faint {
 
-inline ROOT::RDF::RNode open_frame(const std::string &base_dir, 
-                                   const std::string &rel,
-                                   IEventProcessor &processor, 
-                                   SampleOrigin origin) {
-    auto path = base_dir + "/" + rel;
-    ROOT::RDataFrame df("nuselection/EventSelectionFilter", path);
-    return processor.process(df, origin);
-}
-
-inline ROOT::RDF::RNode filter_truth(ROOT::RDF::RNode df, const std::string &truth) {
-    return truth.empty() ? df : df.Filter(truth);
-}
-
-inline ROOT::RDF::RNode exclude_truth(ROOT::RDF::RNode df, 
-                                      const std::vector<std::string> &keys,
-                                      const nlohmann::json &all) {
-    for (const auto &k : keys) {
-        bool found = false;
-        for (const auto &s : all) {
-            if (s.at("sample_key").get<std::string>() == k) {
-                if (s.contains("truth")) {
-                    auto filter_str = s.at("truth").get<std::string>();
-                    df = df.Filter("!(" + filter_str + ")");
-                    found = true;
-                    break;
-                }
-            }
-        }
-        if (!found) log::warn("Sample::exclude_truth", "Exclusion k not found or missing truth:", k);
-    }
-    return df;
-}
-
 class Sample {
-  public:
-    SampleKey key_;
-    SampleOrigin origin_;
+ public:
+  Sample(const nlohmann::json& j, const nlohmann::json& all,
+         const std::string& base_dir, const VariableRegistry& vars,
+         IEventProcessor& processor);
 
-    std::string path_;
-    std::string truth_;
-    std::vector<std::string> exclude_;
+  void validate(const std::string& base_dir) const;
 
-    double pot_{0.0};
-    long triggers_{0};
+  SampleKey key_;
+  SampleOrigin origin_;
 
-    ROOT::RDF::RNode node_;
-    std::map<SampleVariation, ROOT::RDF::RNode> variations_;
+  std::string path_;
+  std::string truth_;
+  std::vector<std::string> exclude_;
 
-    Sample(const nlohmann::json &j, 
-           const nlohmann::json &all, 
-           const std::string &base_dir,
-           const VariableRegistry &vars, 
-           IEventProcessor &processor)
-        : key_{j.at("sample_key").get<std::string>()},
-          origin_{[&]() {
-              auto ts = j.at("sample_type").get<std::string>();
-              return (ts == "mc"     ? SampleOrigin::kMonteCarlo
-                      : ts == "data" ? SampleOrigin::kData
-                      : ts == "ext"  ? SampleOrigin::kExternal
-                      : ts == "dirt" ? SampleOrigin::kDirt
-                                      : SampleOrigin::kUnknown);
-          }()},
-          path_{j.value("relative_path", "")},
-          truth_{j.value("truth", "")},
-          exclude_{j.value("exclusion_truth_filters", std::vector<std::string>{})},
-          pot_{j.value("pot", 0.0)},
-          triggers_{j.value("triggers", 0L)},
-          node_{build(base_dir, vars, processor, path_, all)} {
-        if (j.contains("detector_variations")) {
-            for (auto &dv : j.at("detector_variations")) {
-                SampleVariation dvt = this->parse_variation(dv.at("variation_type").get<std::string>());
-                variation_paths_[dvt] = dv.at("relative_path").get<std::string>();
-            }
-        }
-        this->validate(base_dir);
-        if (origin_ == SampleOrigin::kMonteCarlo) {
-            for (auto &[v, path] : variation_paths_) {
-                variations_.emplace(v, this->build(base_dir, vars, processor, path, all));
-            }
-        }
-    }
+  double pot_{0.0};
+  long triggers_{0};
 
-    void validate(const std::string &base_dir) const {
-        if (key_.str().empty()) log::fatal("Sample::validate", "empty key_");
-        if (origin_ == SampleOrigin::kUnknown) log::fatal("Sample::validate", "unknown  for", key_.str());
-        if ((origin_ == SampleOrigin::kMonteCarlo || origin_ == SampleOrigin::kDirt) && pot_ <= 0) log::fatal("Sample::validate", "invalid pot_ for MC/Dirt", key_.str());
-        if (origin_ == SampleOrigin::kData && triggers_ <= 0) log::fatal("Sample::validate", "invalid triggers_ for Data", key_.str());
-        if (origin_ != SampleOrigin::kData && path_.empty()) log::fatal("Sample::validate", "missing path for", key_.str());
-        
-        if (!path_.empty()) {
-            auto p = std::filesystem::path(base_dir) / path_;
-            if (!std::filesystem::exists(p))
-                log::fatal("Sample::validate", "missing file", p.string());
-        }
+  ROOT::RDF::RNode node_;
+  std::map<SampleVariation, ROOT::RDF::RNode> variations_;
 
-        for (auto &[v, rp] : variation_paths_) {
-            auto vp = std::filesystem::path(base_dir) / rp;
-            if (!std::filesystem::exists(vp)) log::fatal("Sample::validate", "missing variation", rp);
-        }
-    }
+ private:
+  std::map<SampleVariation, std::string> variation_paths_;
 
-  private:
-    std::map<SampleVariation, std::string> variation_paths_;
-
-    SampleVariation parse_variation(const std::string &s) const {
-        if (s == "cv") return SampleVariation::kCV;
-        if (s == "lyatt") return SampleVariation::kLYAttenuation;
-        if (s == "lydown") return SampleVariation::kLYDown;
-        if (s == "lyray") return SampleVariation::kLYRayleigh;
-        if (s == "recomb2") return SampleVariation::kRecomb2;
-        if (s == "sce") return SampleVariation::kSCE;
-        if (s == "wiremodx") return SampleVariation::kWireModX;
-        if (s == "wiremodyz") return SampleVariation::kWireModYZ;
-        if (s == "wiremodanglexz") return SampleVariation::kWireModAngleXZ;
-        if (s == "wiremodangleyz") return SampleVariation::kWireModAngleYZ;
-        log::fatal("Sample::parse_variation", "invalid detvar_type:", s);
-        return SampleVariation::kUnknown;
-    }
-
-    ROOT::RDF::RNode build(const std::string& base_dir, 
-                           const VariableRegistry&, 
-                           IEventProcessor& processor,
-                           const std::string& rel, 
-                           const nlohmann::json& all) {
-        auto df = this->open_frame(base_dir, rel, processor, origin_);
-        df = this->filter_truth(df, truth_);
-        df = this->exclude_truth(df, exclude_, all);
-        return df;
-    }
+  SampleVariation parse_variation(const std::string& s) const;
+  ROOT::RDF::RNode build(const std::string& base_dir, const VariableRegistry& vars,
+                         IEventProcessor& processor, const std::string& rel,
+                         const nlohmann::json& all);
 };
 
-}
+}  // namespace faint
 
 #endif

--- a/include/faint/SampleSet.h
+++ b/include/faint/SampleSet.h
@@ -9,163 +9,70 @@
 
 #include "ROOT/RDataFrame.hxx"
 
+#include <faint/PreSelection.h>
+#include <faint/Run.h>
+#include <faint/RunReader.h>
+#include <faint/Sample.h>
+#include <faint/TruthClassifier.h>
+#include <faint/Weighter.h>
 #include <faint/core/AnalysisKey.h>
-#include <faint/data/BlipProcessor.h>
-#include <faint/data/IEventProcessor.h>
-#include <faint/utils/Logger.h>
-#include <faint/data/MuonSelectionProcessor.h>
-#include <faint/data/NuMuCCSelectionProcessor.h>
-#include <faint/data/PreselectionProcessor.h>
-#include <faint/data/ReconstructionProcessor.h>
-#include <faint/data/RunCatalog.h>
-#include <faint/data/Samples.h>
 #include <faint/core/SelectionQuery.h>
-#include <faint/data/TruthChannelProcessor.h>
-#include <faint/data/VariableRegistry.h>
-#include <faint/data/WeightProcessor.h>
+#include <faint/Variables.h>
+
+namespace nlohmann {
+class json;
+}
 
 namespace faint {
 
 class SampleSet {
-  public:
-    using Map = std::map<SampleKey, Samples>;
+ public:
+  using Map = std::map<SampleKey, Samples>;
 
-    SampleSet(const RunCatalog &runs, 
-              VariableRegistry variables,
-              const std::string &beam,
-              std::vector<std::string> periods,
-              const std::string &ntuple_dir, 
-              bool blind = true)
-        : runs_(runs),
-          variables_(std::move(variables)),
-          ntuple_dir_(ntuple_dir),
-          beam_(beam),
-          periods_(std::move(periods)),
-          blind_(blind),
-          total_pot_(0.0),
-          total_triggers_(0) {
-        this->();
-    }
+  SampleSet(const RunCatalog& runs, VariableRegistry variables,
+            const std::string& beam, std::vector<std::string> periods,
+            const std::string& ntuple_dir, bool blind = true);
 
-    Map &frames() noexcept { return samples_; }
+  Map& frames() noexcept;
 
-    double total_pot() const noexcept { return total_pot_; }
+  double total_pot() const noexcept;
+  long total_triggers() const noexcept;
 
-    long total_triggers() const noexcept { return total_triggers_; }
+  const std::string& beam() const noexcept;
+  const std::vector<std::string>& periods() const noexcept;
 
-    const std::string &beam() const noexcept { return beam_; }
+  const Run* run_for(const SampleKey& sk) const;
 
-    const std::vector<std::string> &periods() const noexcept { return periods_; }
+  void snapshot(const std::string& filter, const std::string& out,
+                const std::vector<std::string>& cols = {}) const;
+  void snapshot(const SelectionQuery& query, const std::string& out,
+                const std::vector<std::string>& cols = {}) const;
 
-    const Run* run_for(const SampleKey &sk) const {
-        auto it = run_cache_.find(sk);
-        if (it != run_cache_.end()) ? it->second : nullptr;
-    }
+  void print_branches();
 
-    void snapshot(const std::string &filter, 
-                  const std::string &out,
-                  const std::vector<std::string> &cols = {}) const {
-        bool first = true;
-        ROOT::RDF::RSnapshotOptions opts;
-        for (auto const &[key, sample] : samples_) {
-            auto df = sample.nominal_node_;
-            if (!filter.empty()) df = df.Filter(filter);
-            opts.fMode = first ? "RECREATE" : "UPDATE";
-            df.Snapshot(key.c_str(), out, cols, opts);
-            first = false;
-        }
-    }
+ private:
+  const RunCatalog& runs_;
+  VariableRegistry variables_;
+  std::string ntuple_dir_;
 
-    void snapshot(const SelectionQuery &query, 
-                  const std::string &out,
-                  const std::vector<std::string> &cols = {}) const {
-        this->snapshot(query.str(), out, cols);
-    }
+  std::string beam_;
+  std::vector<std::string> periods_;
+  bool blind_;
 
-    void print_branches() {
-        log::debug("SampleSet::print_branches", "Available branches in loaded samples:");
-        for (auto &[sample_key, sample_def] : samples_) {
-            log::debug("SampleSet::print_branches", "--- Sample:", sample_key.str(), "---");
-            auto branches = sample_def.nominal_node_.GetColumnNames();
-            for (const auto &branch : branches) {
-                log::debug("SampleSet::print_branches", "  - ", branch);
-            }
-        }
-    }
+  double total_pot_;
+  long total_triggers_;
 
-  private:
-    const RunCatalog &runs_;
-    VariableRegistry variables_;
-    std::string ntuple_dir_;
+  Map samples_;
+  std::vector<std::unique_ptr<IEventProcessor>> processors_;
+  std::unordered_map<SampleKey, const Run*> run_cache_;
 
-    std::string beam_;
-    std::vector<std::string> periods_;
-    bool blind_;
-
-    double total_pot_;
-    long total_triggers_;
-
-    Map samples_;
-    std::vector<std::unique_ptr<IEventProcessor>> processors_;
-    std::unordered_map<SampleKey, const Run* > run_cache_;
-
-    void build() {
-        const std::string ext_beam{"numi_ext"}; // this is wrong, change this!
-        std::vector<const Run*> to_process;
-
-        for (auto &p : periods_) {
-            const auto &rc = runs_.get(beam_, p);
-            total_pot_ += rc.nominal_pot;
-            total_triggers_ += rc.nominal_triggers;
-            to_process.push_back(&rc);
-
-            auto key = ext_beam + ":" + p;
-            if (runs_.all().count(key)) {
-                const auto &er = runs_.get(ext_beam, p);
-                total_pot_ += er.nominal_pot;
-                total_triggers_ += er.nominal_triggers;
-                to_process.push_back(&er);
-            }
-        }
-
-        for (const Run* rc : to_process) this->add_run(*rc);
-    }
-
-    void add_run(const Run& rc) {
-        processors_.reserve(processors_.size() + rc.samples.size());
-        for (auto &s : rc.samples) {
-            if (s.contains("active") && !s.at("active").get<bool>()) {
-                log::info("SampleSet::add_run", "Skipping inactive sample: ", s.at("sample_key").get<std::string>());
-                continue;
-            }
-
-            auto pipeline = this->chain(
-                std::make_unique<Weighter>(s, total_pot_, total_triggers_),
-                std::make_unique<PreSelection>(),
-                std::make_unique<MuonSelector>(),
-                std::make_unique<TruthClassifier>(),
-            processors_.push_back(std::move(pipeline));
-
-            auto &proc = *processors_.back();
-            Samples sample{s, rc.samples, ntuple_dir_, variables_, proc};
-
-            run_cache_.emplace(sample.sample_key_, &rc);
-            samples_.emplace(sample.sample_key_, std::move(sample));
-        }
-    }
-
-    template <typename Head, typename... Tail>
-    std::unique_ptr<IEventProcessor> chain(std::unique_ptr<Head> head, std::unique_ptr<Tail>... tail) {
-        if constexpr (sizeof...(tail) == 0) {
-            return head;
-        } else {
-            auto next = this->chain(std::move(tail)...);
-            head->chain_next(std::move(next));
-            return head;
-        }
-    }
+  void build();
+  void add_run(const Run& rc);
+  std::unique_ptr<IEventProcessor> build_pipeline(const nlohmann::json& sample);
+  void snapshot_impl(const std::string& filter, const std::string& out,
+                     const std::vector<std::string>& cols) const;
 };
 
-}
+}  // namespace faint
 
 #endif

--- a/include/faint/Types.h
+++ b/include/faint/Types.h
@@ -22,21 +22,7 @@ enum class Variation : unsigned int {
     kWireModAngleYZ
 };
 
-inline std::string to_key(Variation var) {
-    switch (var) {
-        case Variation::kCV:              return "CV";
-        case Variation::kLYAttenuation:   return "LYAttenuation";
-        case Variation::kLYDown:          return "LYDown";
-        case Variation::kLYRayleigh:      return "LYRayleigh";
-        case Variation::kRecomb2:         return "Recomb2";
-        case Variation::kSCE:             return "SCE";
-        case Variation::kWireModX:        return "WireModX";
-        case Variation::kWireModYZ:       return "WireModYZ";
-        case Variation::kWireModAngleXZ:  return "WireModAngleXZ";
-        case Variation::kWireModAngleYZ:  return "WireModAngleYZ";
-        default:                          return "Unknown";
-    }
-}
+std::string to_key(Variation var);
 
 } 
 

--- a/include/faint/Variables.h
+++ b/include/faint/Variables.h
@@ -6,227 +6,41 @@
 #include <unordered_set>
 #include <vector>
 
-#include <faint/data/Types.h>
+#include <faint/Types.h>
 
 namespace faint {
 
 class Variables {
-public:
-  using KnobVariations   = std::unordered_map<std::string, std::pair<std::string, std::string>>;
-  using MultiUniverseVars= std::unordered_map<std::string, unsigned>;
+ public:
+  using KnobVariations =
+      std::unordered_map<std::string, std::pair<std::string, std::string>>;
+  using MultiUniverseVars = std::unordered_map<std::string, unsigned>;
 
-  static const KnobVariations &knob_var() {
-    static const KnobVariations m = {
-        {"RPA", {"knobRPAup", "knobRPAdn"}},
-        {"CCMEC", {"knobCCMECup", "knobCCMECdn"}},
-        {"AxFFCCQE", {"knobAxFFCCQEup", "knobAxFFCCQEdn"}},
-        {"VecFFCCQE", {"knobVecFFCCQEup", "knobVecFFCCQEdn"}},
-        {"DecayAngMEC", {"knobDecayAngMECup", "knobDecayAngMECdn"}},
-        {"ThetaDelta2Npi", {"knobThetaDelta2Npiup", "knobThetaDelta2Npidn"}},
-        {"ThetaDelta2NRad", {"knobThetaDelta2NRadup", "knobThetaDelta2NRaddn"}},
-        {"NormCCCOH", {"knobNormCCCOHup", "knobNormCCCOHdn"}},
-        {"NormNCCOH", {"knobNormNCCOHup", "knobNormNCCOHdn"}},
-        {"xsr_scc_Fv3", {"knobxsr_scc_Fv3up", "knobxsr_scc_Fv3dn"}},
-        {"xsr_scc_Fa3", {"knobxsr_scc_Fa3up", "knobxsr_scc_Fa3dn"}}
-    };
-    return m;
-  }
+  static const KnobVariations& knob_var();
 
-  static const MultiUniverseVars &multi_uni_var() {
-    static const MultiUniverseVars m = {
-        {"weightsGenie", 500},
-        {"weightsFlux", 500},
-        {"weightsReint", 500},
-        {"weightsPPFX", 500}
-    };
-    return m;
-  }
+  static const MultiUniverseVars& multi_uni_var();
 
-  static const std::string &single_knob_var() {
-    static const std::string s = "RootinoFix";
-    return s;
-  }
+  static const std::string& single_knob_var();
 
-  static std::vector<std::string> event_var(Origin origin) {
-    auto vars = collect_base_vars();
-    if (origin == Origin::kMonteCarlo || origin == Origin::kDirt) add_mc_vars(vars);
-    return std::vector<std::string>(vars.begin(), vars.end());
-  }
+  static std::vector<std::string> event_var(Origin origin);
 
-private:
-  static std::unordered_set<std::string> collect_base_vars() {
-    std::unordered_set<std::string> vars{().begin(), ().end()};
-    vars.insert(reco_var().begin(),  reco_var().end());
-    vars.insert(track_var().begin(),  track_var().end());
-    vars.insert(proc_evt_var().begin(), proc_evt_var().end());
-    vars.insert(image_var().begin(),     image_var().end());
-    vars.insert(flash_var().begin(),     flash_var().end());
-    vars.insert(energy_var().begin(),    energy_var().end());
-    vars.insert(slice_var().begin(),     slice_var().end());
-    return vars;
-  }
+ private:
+  static std::unordered_set<std::string> collect_base_vars();
+  static void add_mc_vars(std::unordered_set<std::string>& vars);
 
-  static void add_mc_vars(std::unordered_set<std::string> &vars) {
-    vars.insert(truth_var().begin(), truth_var().end());
-    for (auto &kv : knob_var()) {
-      vars.insert(kv.second.first);
-      vars.insert(kv.second.second);
-    }
-    for (auto &kv : multi_uni_var())
-      vars.insert(kv.first);
-    vars.insert(single_knob_var());
-  }
-
-  // ---- groups ----
-  static const std::vector<std::string> &base_var() {
-    static const std::vector<std::string> v = {"run", "sub", "evt"};
-    return v;
-  }
-
-  static const std::vector<std::string> &truth_var() {
-    static const std::vector<std::string> v = {
-      "neutrino_pdg","interaction_ccnc","interaction_mode","interaction_type",
-      "neutrino_energy","neutrino_theta","neutrino_pt","target_nucleus_pdg",
-      "hit_nucleon_pdg","kinematic_W","kinematic_X","kinematic_Y","kinematic_Q_squared",
-      "neutrino_momentum_x","neutrino_momentum_y","neutrino_momentum_z",
-      "neutrino_vertex_x","neutrino_vertex_y","neutrino_vertex_z",
-      "neutrino_vertex_wire_u","neutrino_vertex_wire_v","neutrino_vertex_wire_w",
-      "neutrino_vertex_time","neutrino_sce_vertex_x","neutrino_sce_vertex_y","neutrino_sce_vertex_z",
-      "lepton_energy","true_neutrino_momentum_x","true_neutrino_momentum_y","true_neutrino_momentum_z",
-      "flux_path_length","flux_parent_pdg","flux_hadron_pdg","flux_decay_mode",
-      "flux_decay_vtx_x","flux_decay_vtx_y","flux_decay_vtx_z",
-      "flux_decay_mom_x","flux_decay_mom_y","flux_decay_mom_z",
-      "numi_baseline","numi_off_axis_angle","bnb_baseline","bnb_off_axis_angle",
-      "is_vertex_in_fiducial","count_mu_minus","count_mu_plus","count_e_minus","count_e_plus",
-      "count_pi_zero","count_pi_plus","count_pi_minus","count_kaon_plus","count_kaon_minus","count_kaon_zero",
-      "count_proton","count_neutron","count_gamma","count_lambda",
-      "count_sigma_plus","count_sigma_zero","count_sigma_minus",
-      "mc_particle_pdg","mc_particle_trackid","mc_particle_energy",
-      "mc_elastic_scatters","mc_inelastic_scatters","mc_momentum_x","mc_momentum_y","mc_momentum_z",
-      "mc_end_momentum","mc_start_vertex_x","mc_start_vertex_y","mc_start_vertex_z",
-      "mc_end_vertex_x","mc_end_vertex_y","mc_end_vertex_z",
-      "mc_particle_final_state","mc_completeness","mc_purity",
-      "mc_daughter_pdg","mc_daughter_energy","mc_daughter_process_flat","mc_daughter_process_idx",
-      "mc_daughter_mom_x","mc_daughter_mom_y","mc_daughter_mom_z",
-      "mc_daughter_vtx_x","mc_daughter_vtx_y","mc_daughter_vtx_z",
-      "mc_allchain_primary_index","mc_allchain_trackid","mc_allchain_pdg","mc_allchain_energy",
-      "mc_allchain_elastic_scatters","mc_allchain_inelastic_scatters",
-      "mc_allchain_momentum_x","mc_allchain_momentum_y","mc_allchain_momentum_z","mc_allchain_end_momentum",
-      "mc_allchain_start_vertex_x","mc_allchain_start_vertex_y","mc_allchain_start_vertex_z",
-      "mc_allchain_end_vertex_x","mc_allchain_end_vertex_y","mc_allchain_end_vertex_z",
-      "mc_allchain_parent_trackid","mc_allchain_process","mc_allchain_final_state",
-      "mc_allchain_completeness","mc_allchain_purity",
-      "true_transverse_momentum","true_visible_transverse_momentum",
-      "true_total_momentum","true_visible_total_momentum","true_visible_energy",
-      "neutrino_completeness_from_pfp","neutrino_purity_from_pfp",
-      "backtracked_pdg_codes","blip_pdg"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &reco_var() {
-    static const std::vector<std::string> v = {
-      "reco_neutrino_vertex_sce_x","reco_neutrino_vertex_sce_y","reco_neutrino_vertex_sce_z",
-      "num_slices","slice_num_hits","selection_pass","slice_id",
-      "optical_filter_pe_beam","optical_filter_pe_veto",
-      "num_pfps","num_tracks","num_showers","event_total_hits",
-      "crt_veto","crt_hit_pe","pfp_slice_indices",
-      "backtracked_pdg_codes","backtracked_energies","backtracked_track_ids",
-      "backtracked_purities","backtracked_completenesses","backtracked_overlay_purities",
-      "backtracked_momentum_x","backtracked_momentum_y","backtracked_momentum_z",
-      "backtracked_start_x","backtracked_start_y","backtracked_start_z",
-      "backtracked_start_time","backtracked_start_wire_U","backtracked_start_wire_V","backtracked_start_wire_Y",
-      "backtracked_sce_start_x","backtracked_sce_start_y","backtracked_sce_start_z",
-      "backtracked_sce_start_wire_U","backtracked_sce_start_wire_V","backtracked_sce_start_wire_Y",
-      "software_trigger","software_trigger_pre","software_trigger_post",
-      "software_trigger_pre_ext","software_trigger_post_ext",
-      "slice_pdg","pfp_generations","pfp_track_daughters","pfp_shower_daughters",
-      "pfp_num_descendents","pfp_vertex_x","pfp_vertex_y","pfp_vertex_z",
-      "track_shower_scores","pfp_pdg_codes","pfp_num_hits",
-      "pfp_num_plane_hits_U","pfp_num_plane_hits_V","pfp_num_plane_hits_Y",
-      "pfp_num_subclusters_U","pfp_num_subclusters_V","pfp_num_subclusters_Y",
-      "pfp_max_subhit_fraction_U","pfp_max_subhit_fraction_V","pfp_max_subhit_fraction_Y",
-      "total_hits_U","total_hits_V","total_hits_Y",
-      "slice_topological_scores","topological_score","slice_cluster_fraction","contained_fraction"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &image_var() {
-    static const std::vector<std::string> v = {
-      "reco_neutrino_vertex_x","reco_neutrino_vertex_y","reco_neutrino_vertex_z",
-      "detector_image_u","detector_image_v","detector_image_w",
-      "semantic_image_u","semantic_image_v","semantic_image_w",
-      "event_detector_image_u","event_detector_image_v","event_detector_image_w",
-      "event_semantic_image_u","event_semantic_image_v","event_semantic_image_w",
-      "event_adc_u","event_adc_v","event_adc_w",
-      "slice_semantic_counts_u","slice_semantic_counts_v","slice_semantic_counts_w",
-      "event_semantic_counts_u","event_semantic_counts_v","event_semantic_counts_w",
-      "is_vtx_in_image_u","is_vtx_in_image_v","is_vtx_in_image_w","inference_score"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &flash_var() {
-    static const std::vector<std::string> v = {
-      "t0","flash_match_score","flash_total_pe","flash_time","flash_z_center","flash_z_width",
-      "slice_charge","slice_z_center","charge_light_ratio","flash_slice_z_dist","flash_pe_per_charge"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &energy_var() {
-    static const std::vector<std::string> v = {
-      "neutrino_energy_0","neutrino_energy_1","neutrino_energy_2",
-      "slice_calo_energy_0","slice_calo_energy_1","slice_calo_energy_2"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &slice_var() {
-    static const std::vector<std::string> v = {
-      "original_event_neutrino_hits","event_neutrino_hits","event_muon_hits","event_electron_hits",
-      "event_proton_hits","event_charged_pion_hits","event_neutral_pion_hits","event_neutron_hits",
-      "event_gamma_hits","event_other_hits","event_charged_kaon_hits","event_neutral_kaon_hits",
-      "event_lambda_hits","event_charged_sigma_hits","event_sigma_zero_hits","event_cosmic_hits",
-      "slice_neutrino_hits","slice_muon_hits","slice_electron_hits","slice_proton_hits",
-      "slice_charged_pion_hits","slice_neutral_pion_hits","slice_neutron_hits","slice_gamma_hits",
-      "slice_other_hits","slice_charged_kaon_hits","slice_neutral_kaon_hits","slice_lambda_hits",
-      "slice_charged_sigma_hits","slice_sigma_zero_hits","slice_cosmic_hits",
-      "pfp_neutrino_hits","pfp_muon_hits","pfp_electron_hits","pfp_proton_hits",
-      "pfp_charged_pion_hits","pfp_neutral_pion_hits","pfp_neutron_hits","pfp_gamma_hits","pfp_other_hits",
-      "pfp_charged_kaon_hits","pfp_neutral_kaon_hits","pfp_lambda_hits",
-      "pfp_charged_sigma_hits","pfp_sigma_zero_hits","pfp_cosmic_hits",
-      "neutrino_completeness_from_pfp","neutrino_purity_from_pfp"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &track_var() {
-    static const std::vector<std::string> v = {
-      "track_shower_scores","trk_llr_pid_v","track_length","track_distance_to_vertex",
-      "track_start_x","track_start_y","track_start_z","track_end_x","track_end_y","track_end_z",
-      "track_theta","track_phi","track_calo_energy_u","track_calo_energy_v","track_calo_energy_y"
-    };
-    return v;
-  }
-
-  static const std::vector<std::string> &proc_evt_var() {
-    static const std::vector<std::string> v = {
-      "in_reco_fiducial","reco_nu_vtx_sce_x","reco_nu_vtx_sce_y","reco_nu_vtx_sce_z",
-      "n_pfps_gen2","n_pfps_gen3","quality_event","n_muons_tot","has_muon",
-      "muon_trk_score_v","muon_trk_llr_pid_v","muon_trk_start_x_v","muon_trk_start_y_v","muon_trk_start_z_v",
-      "muon_trk_end_x_v","muon_trk_end_y_v","muon_trk_end_z_v","muon_trk_length_v","muon_trk_distance_v",
-      "muon_pfp_generation_v","muon_trk_range_muon_mom_v","muon_track_costheta",
-      "base_event_weight","nominal_event_weight","in_fiducial",
-      "mc_n_strange","mc_n_pion","mc_n_proton","genie_int_mode","incl_channel","excl_channel"
-    };
-    return v;
-  }
+  static const std::vector<std::string>& base_var();
+  static const std::vector<std::string>& truth_var();
+  static const std::vector<std::string>& reco_var();
+  static const std::vector<std::string>& image_var();
+  static const std::vector<std::string>& flash_var();
+  static const std::vector<std::string>& energy_var();
+  static const std::vector<std::string>& slice_var();
+  static const std::vector<std::string>& track_var();
+  static const std::vector<std::string>& proc_evt_var();
 };
 
 using VariableRegistry = Variables;
 
-} // namespace faint
+}  // namespace faint
 
 #endif

--- a/include/faint/Weighter.h
+++ b/include/faint/Weighter.h
@@ -4,66 +4,17 @@
 #include <cmath>
 #include <nlohmann/json.hpp>
 
-#include <faint/utils/Logger.h>
-#include <faint/data/EventProcessor.h>
-#include <faint/data/Types.h>
+#include <faint/EventProcessor.h>
+#include <faint/Types.h>
 
 namespace faint {
 
 class Weighter : public EventProcessor {
 public:
-  Weighter(const nlohmann::json& cfg, double total_run_pot, long total_run_triggers)
-    : sample_pot_(cfg.value("pot", 0.0)),
-      sample_triggers_(cfg.value("triggers", 0L)),
-      total_run_pot_(total_run_pot),
-      total_run_triggers_(total_run_triggers) {
+  Weighter(const nlohmann::json& cfg, double total_run_pot,
+           long total_run_triggers);
 
-    if (sample_pot_ <= 0.0 && sample_triggers_ <= 0L) {
-      log::warn("Weighter::Weighter",
-                "sample JSON has no or invalid 'pot' or 'triggers'; "
-                "base_event_weight will default to 1");
-    }
-  }
-
-  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override {
-    ROOT::RDF::RNode node = df;
-
-    if (origin == Origin::kMonteCarlo || origin == Origin::kDirt) {
-      double scale = 1.0;
-      if (sample_pot_ > 0.0 && total_run_pot_ > 0.0)
-        scale = total_run_pot_ / sample_pot_;
-
-      node = node.Define("base_event_weight", [scale]() { return scale; });
-
-      node = node.Define(
-        "nominal_event_weight",
-        [](double w, float w_spline, float w_tune) {
-          double out = w;
-          if (std::isfinite(w_spline) && w_spline > 0) out *= w_spline;
-          if (std::isfinite(w_tune)   && w_tune   > 0) out *= w_tune;
-          if (!std::isfinite(out) || out < 0) return 1.0;
-          return out;
-        },
-        {"base_event_weight", "weightSpline", "weightTune"});
-
-    } else if (origin == Origin::kExternal) {
-      double scale = 1.0;
-      if (sample_triggers_ > 0 && total_run_triggers_ > 0) {
-        scale = static_cast<double>(total_run_triggers_) /
-                static_cast<double>(sample_triggers_);
-      }
-      node = node.Define("base_event_weight", [scale]() { return scale; });
-    }
-
-    if (!node.HasColumn("nominal_event_weight")) {
-      if (node.HasColumn("base_event_weight"))
-        node = node.Alias("nominal_event_weight", "base_event_weight");
-      else
-        node = node.Define("nominal_event_weight", [](){ return 1.0; });
-    }
-
-    return next_ ? next_->process(node, origin) : node;
-  }
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override;
 
 private:
   double sample_pot_;

--- a/src/Campaign.cc
+++ b/src/Campaign.cc
@@ -74,6 +74,22 @@ void Campaign::snapshot_final(const std::string& out_file,
     snapshot_where(sel::Final, out_file, columns);
 }
 
+double Campaign::pot() const noexcept { return set().total_pot(); }
+
+long Campaign::triggers() const noexcept { return set().total_triggers(); }
+
+const std::string& Campaign::beam() const noexcept { return opt_.beam; }
+
+const std::vector<std::string>& Campaign::periods() const noexcept {
+    return opt_.periods;
+}
+
+const SampleSet& Campaign::samples() const { return set(); }
+
+const RunCatalog& Campaign::runs() const { return runs_; }
+
+const SampleSet& Campaign::set() const { return *set_; }
+
 const Sample* Campaign::find_sample(std::string_view key) const {
     const auto& frames = const_cast<SampleSet&>(set()).frames();
     for (auto const& kv : frames) {

--- a/src/EventProcessor.cc
+++ b/src/EventProcessor.cc
@@ -1,3 +1,9 @@
 #include "faint/EventProcessor.h"
 
-// Translation unit generated to accompany the header-only implementation.
+namespace faint {
+
+void EventProcessor::chain_processor(std::unique_ptr<EventProcessor> next) {
+  next_ = std::move(next);
+}
+
+}  // namespace faint

--- a/src/Run.cc
+++ b/src/Run.cc
@@ -1,3 +1,41 @@
 #include "faint/Run.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <set>
+#include <utility>
+
+#include "faint/utils/Logger.h"
+
+namespace faint {
+
+Run::Run(const json& j, std::string bm, std::string pr)
+    : beam_mode(std::move(bm)),
+      run_period(std::move(pr)),
+      nominal_pot(j.value("nominal_pot",
+                          j.value("pot_target_wcut_total",
+                                  j.value("torb_target_pot_wcut", 0.0)))),
+      nominal_triggers(j.value("nominal_triggers",
+                               j.value("ext_triggers_total",
+                                       j.value("ext_triggers", 0L)))),
+      samples(j.at("samples")) {}
+
+std::string Run::key() const { return beam_mode + ":" + run_period; }
+
+std::string Run::label() const { return key(); }
+
+void Run::validate() const {
+  if (beam_mode.empty())
+    log::fatal("Run::validate", "empty beam_mode");
+  if (run_period.empty())
+    log::fatal("Run::validate", "empty run_period");
+  if (samples.empty())
+    log::fatal("Run::validate", "no samples for", beam_mode + "/" + run_period);
+
+  std::set<std::string> keys;
+  for (auto& s : samples) {
+    std::string key = s.at("sample_key").get<std::string>();
+    if (!keys.insert(key).second)
+      log::fatal("Run::validate", "duplicate sample key:", key);
+  }
+}
+
+}  // namespace faint

--- a/src/RunReader.cc
+++ b/src/RunReader.cc
@@ -1,3 +1,58 @@
 #include "faint/RunReader.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <fstream>
+#include <stdexcept>
+#include <utility>
+
+#include "faint/utils/Logger.h"
+
+namespace faint {
+
+void RunReader::add(Run rc) {
+  auto key = rc.label();
+  if (configs_.count(key))
+    throw std::runtime_error("Duplicate Run label: " + key);
+  configs_.emplace(std::move(key), std::move(rc));
+}
+
+const Run& RunReader::get(const std::string& beam,
+                          const std::string& period) const {
+  auto key = beam + ":" + period;
+  auto it = configs_.find(key);
+  if (it == configs_.end())
+    throw std::out_of_range("Run not found: " + key);
+  return it->second;
+}
+
+const std::map<std::string, Run>& RunReader::all() const noexcept {
+  return configs_;
+}
+
+RunReader RunReader::read(const nlohmann::json& data) {
+  RunReader out;
+  const std::string top =
+      data.contains("run_configurations") ? "run_configurations" : "beamlines";
+  for (auto const& [beam, runs] : data.at(top).items()) {
+    for (auto const& [period, details] : runs.items()) {
+      Run rc(details, beam, period);
+      rc.validate();
+      out.add(std::move(rc));
+    }
+  }
+  return out;
+}
+
+RunReader RunReader::read(const std::string& path) {
+  std::ifstream f(path);
+  if (!f.is_open())
+    log::fatal("RunReader::read", "Could not open config file:", path);
+  try {
+    nlohmann::json data = nlohmann::json::parse(f);
+    return read(data);
+  } catch (const std::exception& e) {
+    log::fatal("RunReader::read", "Parsing error:", e.what());
+  }
+  return {};
+}
+
+}  // namespace faint

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -1,3 +1,131 @@
 #include "faint/Sample.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <filesystem>
+#include <utility>
+
+#include "faint/utils/Logger.h"
+
+namespace faint {
+namespace {
+
+ROOT::RDF::RNode open_frame(const std::string& base_dir, const std::string& rel,
+                            IEventProcessor& processor, SampleOrigin origin) {
+  auto path = base_dir + "/" + rel;
+  ROOT::RDataFrame df("nuselection/EventSelectionFilter", path);
+  return processor.process(df, origin);
+}
+
+ROOT::RDF::RNode filter_truth(ROOT::RDF::RNode df, const std::string& truth) {
+  return truth.empty() ? df : df.Filter(truth);
+}
+
+ROOT::RDF::RNode exclude_truth(ROOT::RDF::RNode df,
+                               const std::vector<std::string>& keys,
+                               const nlohmann::json& all) {
+  for (const auto& k : keys) {
+    bool found = false;
+    for (const auto& s : all) {
+      if (s.at("sample_key").get<std::string>() == k) {
+        if (s.contains("truth")) {
+          auto filter_str = s.at("truth").get<std::string>();
+          df = df.Filter("!(" + filter_str + ")");
+          found = true;
+          break;
+        }
+      }
+    }
+    if (!found)
+      log::warn("Sample::exclude_truth", "Exclusion k not found or missing truth:", k);
+  }
+  return df;
+}
+
+}  // namespace
+
+Sample::Sample(const nlohmann::json& j, const nlohmann::json& all,
+               const std::string& base_dir, const VariableRegistry& vars,
+               IEventProcessor& processor)
+    : key_{j.at("sample_key").get<std::string>()},
+      origin_{[&]() {
+        auto ts = j.at("sample_type").get<std::string>();
+        if (ts == "mc") return SampleOrigin::kMonteCarlo;
+        if (ts == "data") return SampleOrigin::kData;
+        if (ts == "ext") return SampleOrigin::kExternal;
+        if (ts == "dirt") return SampleOrigin::kDirt;
+        return SampleOrigin::kUnknown;
+      }()},
+      path_{j.value("relative_path", "")},
+      truth_{j.value("truth", "")},
+      exclude_{j.value("exclusion_truth_filters", std::vector<std::string>{})},
+      pot_{j.value("pot", 0.0)},
+      triggers_{j.value("triggers", 0L)},
+      node_{build(base_dir, vars, processor, path_, all)} {
+  if (j.contains("detector_variations")) {
+    for (auto& dv : j.at("detector_variations")) {
+      SampleVariation dvt =
+          parse_variation(dv.at("variation_type").get<std::string>());
+      variation_paths_[dvt] = dv.at("relative_path").get<std::string>();
+    }
+  }
+  validate(base_dir);
+  if (origin_ == SampleOrigin::kMonteCarlo) {
+    for (auto& [variation, rel_path] : variation_paths_) {
+      variations_.emplace(variation,
+                          build(base_dir, vars, processor, rel_path, all));
+    }
+  }
+}
+
+void Sample::validate(const std::string& base_dir) const {
+  if (key_.str().empty())
+    log::fatal("Sample::validate", "empty key_");
+  if (origin_ == SampleOrigin::kUnknown)
+    log::fatal("Sample::validate", "unknown  for", key_.str());
+  if ((origin_ == SampleOrigin::kMonteCarlo || origin_ == SampleOrigin::kDirt) &&
+      pot_ <= 0)
+    log::fatal("Sample::validate", "invalid pot_ for MC/Dirt", key_.str());
+  if (origin_ == SampleOrigin::kData && triggers_ <= 0)
+    log::fatal("Sample::validate", "invalid triggers_ for Data", key_.str());
+  if (origin_ != SampleOrigin::kData && path_.empty())
+    log::fatal("Sample::validate", "missing path for", key_.str());
+
+  if (!path_.empty()) {
+    auto p = std::filesystem::path(base_dir) / path_;
+    if (!std::filesystem::exists(p))
+      log::fatal("Sample::validate", "missing file", p.string());
+  }
+
+  for (auto& [variation, rel_path] : variation_paths_) {
+    auto vp = std::filesystem::path(base_dir) / rel_path;
+    if (!std::filesystem::exists(vp))
+      log::fatal("Sample::validate", "missing variation", rel_path);
+  }
+}
+
+SampleVariation Sample::parse_variation(const std::string& s) const {
+  if (s == "cv") return SampleVariation::kCV;
+  if (s == "lyatt") return SampleVariation::kLYAttenuation;
+  if (s == "lydown") return SampleVariation::kLYDown;
+  if (s == "lyray") return SampleVariation::kLYRayleigh;
+  if (s == "recomb2") return SampleVariation::kRecomb2;
+  if (s == "sce") return SampleVariation::kSCE;
+  if (s == "wiremodx") return SampleVariation::kWireModX;
+  if (s == "wiremodyz") return SampleVariation::kWireModYZ;
+  if (s == "wiremodanglexz") return SampleVariation::kWireModAngleXZ;
+  if (s == "wiremodangleyz") return SampleVariation::kWireModAngleYZ;
+  log::fatal("Sample::parse_variation", "invalid detvar_type:", s);
+  return SampleVariation::kUnknown;
+}
+
+ROOT::RDF::RNode Sample::build(const std::string& base_dir,
+                               const VariableRegistry& vars,
+                               IEventProcessor& processor,
+                               const std::string& rel,
+                               const nlohmann::json& all) {
+  auto df = open_frame(base_dir, rel, processor, origin_);
+  df = filter_truth(df, truth_);
+  df = exclude_truth(df, exclude_, all);
+  return df;
+}
+
+}  // namespace faint

--- a/src/SampleSet.cc
+++ b/src/SampleSet.cc
@@ -1,3 +1,134 @@
 #include "faint/SampleSet.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <nlohmann/json.hpp>
+
+#include "faint/MuonSelector.h"
+#include "faint/utils/Logger.h"
+
+namespace faint {
+
+SampleSet::SampleSet(const RunCatalog& runs, VariableRegistry variables,
+                     const std::string& beam, std::vector<std::string> periods,
+                     const std::string& ntuple_dir, bool blind)
+    : runs_(runs),
+      variables_(std::move(variables)),
+      ntuple_dir_(ntuple_dir),
+      beam_(beam),
+      periods_(std::move(periods)),
+      blind_(blind),
+      total_pot_(0.0),
+      total_triggers_(0) {
+  build();
+}
+
+SampleSet::Map& SampleSet::frames() noexcept { return samples_; }
+
+double SampleSet::total_pot() const noexcept { return total_pot_; }
+
+long SampleSet::total_triggers() const noexcept { return total_triggers_; }
+
+const std::string& SampleSet::beam() const noexcept { return beam_; }
+
+const std::vector<std::string>& SampleSet::periods() const noexcept {
+  return periods_;
+}
+
+const Run* SampleSet::run_for(const SampleKey& sk) const {
+  auto it = run_cache_.find(sk);
+  return it != run_cache_.end() ? it->second : nullptr;
+}
+
+void SampleSet::snapshot(const std::string& filter, const std::string& out,
+                         const std::vector<std::string>& cols) const {
+  snapshot_impl(filter, out, cols);
+}
+
+void SampleSet::snapshot(const SelectionQuery& query, const std::string& out,
+                         const std::vector<std::string>& cols) const {
+  snapshot_impl(query.str(), out, cols);
+}
+
+void SampleSet::print_branches() {
+  log::debug("SampleSet::print_branches",
+             "Available branches in loaded samples:");
+  for (auto& [sample_key, sample_def] : samples_) {
+    log::debug("SampleSet::print_branches", "--- Sample:", sample_key.str(),
+               "---");
+    auto branches = sample_def.nominal_node_.GetColumnNames();
+    for (const auto& branch : branches) {
+      log::debug("SampleSet::print_branches", "  - ", branch);
+    }
+  }
+}
+
+void SampleSet::build() {
+  const std::string ext_beam{"numi_ext"};
+  std::vector<const Run*> to_process;
+
+  for (auto& p : periods_) {
+    const auto& rc = runs_.get(beam_, p);
+    total_pot_ += rc.nominal_pot;
+    total_triggers_ += rc.nominal_triggers;
+    to_process.push_back(&rc);
+
+    auto key = ext_beam + ":" + p;
+    if (runs_.all().count(key)) {
+      const auto& er = runs_.get(ext_beam, p);
+      total_pot_ += er.nominal_pot;
+      total_triggers_ += er.nominal_triggers;
+      to_process.push_back(&er);
+    }
+  }
+
+  for (const Run* rc : to_process) add_run(*rc);
+}
+
+void SampleSet::add_run(const Run& rc) {
+  processors_.reserve(processors_.size() + rc.samples.size());
+  for (auto& s : rc.samples) {
+    if (s.contains("active") && !s.at("active").get<bool>()) {
+      log::info("SampleSet::add_run", "Skipping inactive sample: ",
+                s.at("sample_key").get<std::string>());
+      continue;
+    }
+
+    auto pipeline = build_pipeline(s);
+    processors_.push_back(std::move(pipeline));
+
+    auto& proc = *processors_.back();
+    Samples sample{s, rc.samples, ntuple_dir_, variables_, proc};
+
+    run_cache_.emplace(sample.sample_key_, &rc);
+    samples_.emplace(sample.sample_key_, std::move(sample));
+  }
+}
+
+std::unique_ptr<IEventProcessor> SampleSet::build_pipeline(
+    const nlohmann::json& sample) {
+  auto weighter =
+      std::make_unique<Weighter>(sample, total_pot_, total_triggers_);
+  auto preselection = std::make_unique<PreSelection>();
+  auto muon_selector = std::make_unique<MuonSelector>();
+  auto truth_classifier = std::make_unique<TruthClassifier>();
+
+  muon_selector->chain_processor(std::move(truth_classifier));
+  preselection->chain_processor(std::move(muon_selector));
+  weighter->chain_processor(std::move(preselection));
+
+  return weighter;
+}
+
+void SampleSet::snapshot_impl(const std::string& filter, const std::string& out,
+                              const std::vector<std::string>& cols) const {
+  bool first = true;
+  ROOT::RDF::RSnapshotOptions opts;
+  for (auto const& [key, sample] : samples_) {
+    auto df = sample.nominal_node_;
+    if (!filter.empty()) df = df.Filter(filter);
+    opts.fMode = first ? "RECREATE" : "UPDATE";
+    df.Snapshot(key.c_str(), out, cols, opts);
+    first = false;
+  }
+}
+
+}  // namespace faint

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -1,3 +1,32 @@
 #include "faint/Types.h"
 
-// Translation unit generated to accompany the header-only implementation.
+namespace faint {
+
+std::string to_key(Variation var) {
+  switch (var) {
+    case Variation::kCV:
+      return "CV";
+    case Variation::kLYAttenuation:
+      return "LYAttenuation";
+    case Variation::kLYDown:
+      return "LYDown";
+    case Variation::kLYRayleigh:
+      return "LYRayleigh";
+    case Variation::kRecomb2:
+      return "Recomb2";
+    case Variation::kSCE:
+      return "SCE";
+    case Variation::kWireModX:
+      return "WireModX";
+    case Variation::kWireModYZ:
+      return "WireModYZ";
+    case Variation::kWireModAngleXZ:
+      return "WireModAngleXZ";
+    case Variation::kWireModAngleYZ:
+      return "WireModAngleYZ";
+    default:
+      return "Unknown";
+  }
+}
+
+}  // namespace faint

--- a/src/Variables.cc
+++ b/src/Variables.cc
@@ -1,3 +1,253 @@
 #include "faint/Variables.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <unordered_set>
+#include <utility>
+
+namespace faint {
+
+const Variables::KnobVariations& Variables::knob_var() {
+  static const KnobVariations m = {
+      {"RPA", {"knobRPAup", "knobRPAdn"}},
+      {"CCMEC", {"knobCCMECup", "knobCCMECdn"}},
+      {"AxFFCCQE", {"knobAxFFCCQEup", "knobAxFFCCQEdn"}},
+      {"VecFFCCQE", {"knobVecFFCCQEup", "knobVecFFCCQEdn"}},
+      {"DecayAngMEC", {"knobDecayAngMECup", "knobDecayAngMECdn"}},
+      {"ThetaDelta2Npi", {"knobThetaDelta2Npiup", "knobThetaDelta2Npidn"}},
+      {"ThetaDelta2NRad", {"knobThetaDelta2NRadup", "knobThetaDelta2NRaddn"}},
+      {"NormCCCOH", {"knobNormCCCOHup", "knobNormCCCOHdn"}},
+      {"NormNCCOH", {"knobNormNCCOHup", "knobNormNCCOHdn"}},
+      {"xsr_scc_Fv3", {"knobxsr_scc_Fv3up", "knobxsr_scc_Fv3dn"}},
+      {"xsr_scc_Fa3", {"knobxsr_scc_Fa3up", "knobxsr_scc_Fa3dn"}}};
+  return m;
+}
+
+const Variables::MultiUniverseVars& Variables::multi_uni_var() {
+  static const MultiUniverseVars m = {{"weightsGenie", 500},
+                                      {"weightsFlux", 500},
+                                      {"weightsReint", 500},
+                                      {"weightsPPFX", 500}};
+  return m;
+}
+
+const std::string& Variables::single_knob_var() {
+  static const std::string s = "RootinoFix";
+  return s;
+}
+
+std::vector<std::string> Variables::event_var(Origin origin) {
+  auto vars = collect_base_vars();
+  if (origin == Origin::kMonteCarlo || origin == Origin::kDirt)
+    add_mc_vars(vars);
+  return std::vector<std::string>(vars.begin(), vars.end());
+}
+
+std::unordered_set<std::string> Variables::collect_base_vars() {
+  std::unordered_set<std::string> vars(base_var().begin(), base_var().end());
+  vars.insert(reco_var().begin(), reco_var().end());
+  vars.insert(track_var().begin(), track_var().end());
+  vars.insert(proc_evt_var().begin(), proc_evt_var().end());
+  vars.insert(image_var().begin(), image_var().end());
+  vars.insert(flash_var().begin(), flash_var().end());
+  vars.insert(energy_var().begin(), energy_var().end());
+  vars.insert(slice_var().begin(), slice_var().end());
+  return vars;
+}
+
+void Variables::add_mc_vars(std::unordered_set<std::string>& vars) {
+  vars.insert(truth_var().begin(), truth_var().end());
+  for (const auto& kv : knob_var()) {
+    vars.insert(kv.second.first);
+    vars.insert(kv.second.second);
+  }
+  for (const auto& kv : multi_uni_var())
+    vars.insert(kv.first);
+  vars.insert(single_knob_var());
+}
+
+const std::vector<std::string>& Variables::base_var() {
+  static const std::vector<std::string> v = {"run", "sub", "evt"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::truth_var() {
+  static const std::vector<std::string> v = {
+      "neutrino_pdg",        "interaction_ccnc",      "interaction_mode",
+      "interaction_type",    "neutrino_energy",       "neutrino_theta",
+      "neutrino_pt",         "target_nucleus_pdg",    "hit_nucleon_pdg",
+      "kinematic_W",         "kinematic_X",           "kinematic_Y",
+      "kinematic_Q_squared", "neutrino_momentum_x",   "neutrino_momentum_y",
+      "neutrino_momentum_z", "neutrino_vertex_x",     "neutrino_vertex_y",
+      "neutrino_vertex_z",   "neutrino_vertex_wire_u","neutrino_vertex_wire_v",
+      "neutrino_vertex_wire_w","neutrino_vertex_time", "neutrino_sce_vertex_x",
+      "neutrino_sce_vertex_y","neutrino_sce_vertex_z", "lepton_energy",
+      "true_neutrino_momentum_x","true_neutrino_momentum_y",
+      "true_neutrino_momentum_z", "flux_path_length",  "flux_parent_pdg",
+      "flux_hadron_pdg",     "flux_decay_mode",       "flux_decay_vtx_x",
+      "flux_decay_vtx_y",    "flux_decay_vtx_z",      "flux_decay_mom_x",
+      "flux_decay_mom_y",    "flux_decay_mom_z",      "numi_baseline",
+      "numi_off_axis_angle", "bnb_baseline",          "bnb_off_axis_angle",
+      "is_vertex_in_fiducial","count_mu_minus",       "count_mu_plus",
+      "count_e_minus",       "count_e_plus",          "count_pi_zero",
+      "count_pi_plus",       "count_pi_minus",        "count_kaon_plus",
+      "count_kaon_minus",    "count_kaon_zero",       "count_proton",
+      "count_neutron",       "count_gamma",           "count_lambda",
+      "count_sigma_plus",    "count_sigma_zero",      "count_sigma_minus",
+      "mc_particle_pdg",     "mc_particle_trackid",   "mc_particle_energy",
+      "mc_elastic_scatters", "mc_inelastic_scatters", "mc_momentum_x",
+      "mc_momentum_y",       "mc_momentum_z",         "mc_end_momentum",
+      "mc_start_vertex_x",   "mc_start_vertex_y",     "mc_start_vertex_z",
+      "mc_end_vertex_x",     "mc_end_vertex_y",       "mc_end_vertex_z",
+      "mc_particle_final_state","mc_completeness",    "mc_purity",
+      "mc_daughter_pdg",     "mc_daughter_energy",    "mc_daughter_process_flat",
+      "mc_daughter_process_idx","mc_daughter_mom_x",  "mc_daughter_mom_y",
+      "mc_daughter_mom_z",   "mc_daughter_vtx_x",     "mc_daughter_vtx_y",
+      "mc_daughter_vtx_z",   "mc_allchain_primary_index","mc_allchain_trackid",
+      "mc_allchain_pdg",     "mc_allchain_energy",    "mc_allchain_elastic_scatters",
+      "mc_allchain_inelastic_scatters","mc_allchain_momentum_x",
+      "mc_allchain_momentum_y","mc_allchain_momentum_z","mc_allchain_end_momentum",
+      "mc_allchain_start_vertex_x","mc_allchain_start_vertex_y",
+      "mc_allchain_start_vertex_z", "mc_allchain_end_vertex_x",
+      "mc_allchain_end_vertex_y",    "mc_allchain_end_vertex_z",
+      "mc_allchain_parent_trackid",  "mc_allchain_process",
+      "mc_allchain_final_state",     "mc_allchain_completeness",
+      "mc_allchain_purity",          "true_transverse_momentum",
+      "true_visible_transverse_momentum", "true_total_momentum",
+      "true_visible_total_momentum", "true_visible_energy",
+      "neutrino_completeness_from_pfp", "neutrino_purity_from_pfp",
+      "backtracked_pdg_codes",        "blip_pdg"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::reco_var() {
+  static const std::vector<std::string> v = {
+      "reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",
+      "reco_neutrino_vertex_sce_z", "num_slices",
+      "slice_num_hits", "selection_pass", "slice_id",
+      "optical_filter_pe_beam", "optical_filter_pe_veto",
+      "num_pfps", "num_tracks", "num_showers", "event_total_hits",
+      "crt_veto", "crt_hit_pe", "pfp_slice_indices",
+      "backtracked_pdg_codes", "backtracked_energies",
+      "backtracked_track_ids", "backtracked_purities",
+      "backtracked_completenesses", "backtracked_overlay_purities",
+      "backtracked_momentum_x", "backtracked_momentum_y",
+      "backtracked_momentum_z", "backtracked_start_x",
+      "backtracked_start_y", "backtracked_start_z", "backtracked_start_time",
+      "backtracked_start_wire_U", "backtracked_start_wire_V",
+      "backtracked_start_wire_Y", "backtracked_sce_start_x",
+      "backtracked_sce_start_y", "backtracked_sce_start_z",
+      "backtracked_sce_start_wire_U", "backtracked_sce_start_wire_V",
+      "backtracked_sce_start_wire_Y", "software_trigger",
+      "software_trigger_pre", "software_trigger_post",
+      "software_trigger_pre_ext", "software_trigger_post_ext",
+      "slice_pdg", "pfp_generations", "pfp_track_daughters",
+      "pfp_shower_daughters", "pfp_num_descendents", "pfp_vertex_x",
+      "pfp_vertex_y", "pfp_vertex_z", "track_shower_scores",
+      "pfp_pdg_codes", "pfp_num_hits", "pfp_num_plane_hits_U",
+      "pfp_num_plane_hits_V", "pfp_num_plane_hits_Y", "pfp_num_subclusters_U",
+      "pfp_num_subclusters_V", "pfp_num_subclusters_Y",
+      "pfp_max_subhit_fraction_U", "pfp_max_subhit_fraction_V",
+      "pfp_max_subhit_fraction_Y", "total_hits_U", "total_hits_V",
+      "total_hits_Y", "slice_topological_scores", "topological_score",
+      "slice_cluster_fraction", "contained_fraction"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::image_var() {
+  static const std::vector<std::string> v = {
+      "reco_neutrino_vertex_x",  "reco_neutrino_vertex_y",
+      "reco_neutrino_vertex_z",  "detector_image_u",
+      "detector_image_v",        "detector_image_w",
+      "semantic_image_u",        "semantic_image_v",
+      "semantic_image_w",        "event_detector_image_u",
+      "event_detector_image_v",  "event_detector_image_w",
+      "event_semantic_image_u",  "event_semantic_image_v",
+      "event_semantic_image_w",  "event_adc_u",
+      "event_adc_v",             "event_adc_w",
+      "slice_semantic_counts_u", "slice_semantic_counts_v",
+      "slice_semantic_counts_w", "event_semantic_counts_u",
+      "event_semantic_counts_v", "event_semantic_counts_w",
+      "is_vtx_in_image_u",       "is_vtx_in_image_v",
+      "is_vtx_in_image_w",       "inference_score"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::flash_var() {
+  static const std::vector<std::string> v = {
+      "t0",            "flash_match_score", "flash_total_pe",
+      "flash_time",    "flash_z_center",    "flash_z_width",
+      "slice_charge",  "slice_z_center",    "charge_light_ratio",
+      "flash_slice_z_dist", "flash_pe_per_charge"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::energy_var() {
+  static const std::vector<std::string> v = {
+      "neutrino_energy_0", "neutrino_energy_1", "neutrino_energy_2",
+      "slice_calo_energy_0", "slice_calo_energy_1", "slice_calo_energy_2"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::slice_var() {
+  static const std::vector<std::string> v = {
+      "original_event_neutrino_hits", "event_neutrino_hits",
+      "event_muon_hits",              "event_electron_hits",
+      "event_proton_hits",            "event_charged_pion_hits",
+      "event_neutral_pion_hits",      "event_neutron_hits",
+      "event_gamma_hits",             "event_other_hits",
+      "event_charged_kaon_hits",      "event_neutral_kaon_hits",
+      "event_lambda_hits",            "event_charged_sigma_hits",
+      "event_sigma_zero_hits",        "event_cosmic_hits",
+      "slice_neutrino_hits",          "slice_muon_hits",
+      "slice_electron_hits",          "slice_proton_hits",
+      "slice_charged_pion_hits",      "slice_neutral_pion_hits",
+      "slice_neutron_hits",           "slice_gamma_hits",
+      "slice_other_hits",             "slice_charged_kaon_hits",
+      "slice_neutral_kaon_hits",      "slice_lambda_hits",
+      "slice_charged_sigma_hits",     "slice_sigma_zero_hits",
+      "slice_cosmic_hits",            "pfp_neutrino_hits",
+      "pfp_muon_hits",                "pfp_electron_hits",
+      "pfp_proton_hits",              "pfp_charged_pion_hits",
+      "pfp_neutral_pion_hits",        "pfp_neutron_hits",
+      "pfp_gamma_hits",               "pfp_other_hits",
+      "pfp_charged_kaon_hits",        "pfp_neutral_kaon_hits",
+      "pfp_lambda_hits",              "pfp_charged_sigma_hits",
+      "pfp_sigma_zero_hits",          "pfp_cosmic_hits",
+      "neutrino_completeness_from_pfp", "neutrino_purity_from_pfp"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::track_var() {
+  static const std::vector<std::string> v = {
+      "track_shower_scores",     "trk_llr_pid_v",
+      "track_length",            "track_distance_to_vertex",
+      "track_start_x",           "track_start_y",
+      "track_start_z",           "track_end_x",
+      "track_end_y",             "track_end_z",
+      "track_theta",             "track_phi",
+      "track_calo_energy_u",     "track_calo_energy_v",
+      "track_calo_energy_y"};
+  return v;
+}
+
+const std::vector<std::string>& Variables::proc_evt_var() {
+  static const std::vector<std::string> v = {
+      "in_reco_fiducial",         "reco_nu_vtx_sce_x",
+      "reco_nu_vtx_sce_y",        "reco_nu_vtx_sce_z",
+      "n_pfps_gen2",              "n_pfps_gen3",
+      "quality_event",            "n_muons_tot",
+      "has_muon",                  "muon_trk_score_v",
+      "muon_trk_llr_pid_v",       "muon_trk_start_x_v",
+      "muon_trk_start_y_v",       "muon_trk_start_z_v",
+      "muon_trk_end_x_v",         "muon_trk_end_y_v",
+      "muon_trk_end_z_v",         "muon_trk_length_v",
+      "muon_trk_distance_v",      "muon_pfp_generation_v",
+      "muon_trk_range_muon_mom_v","muon_track_costheta",
+      "base_event_weight",        "nominal_event_weight",
+      "in_fiducial",              "mc_n_strange",
+      "mc_n_pion",                "mc_n_proton",
+      "genie_int_mode",           "incl_channel",
+      "excl_channel"};
+  return v;
+}
+
+}  // namespace faint

--- a/src/Weighter.cc
+++ b/src/Weighter.cc
@@ -1,3 +1,66 @@
 #include "faint/Weighter.h"
 
-// Translation unit generated to accompany the header-only implementation.
+#include <cmath>
+
+#include "faint/utils/Logger.h"
+
+namespace faint {
+
+Weighter::Weighter(const nlohmann::json& cfg, double total_run_pot,
+                   long total_run_triggers)
+    : sample_pot_(cfg.value("pot", 0.0)),
+      sample_triggers_(cfg.value("triggers", 0L)),
+      total_run_pot_(total_run_pot),
+      total_run_triggers_(total_run_triggers) {
+  if (sample_pot_ <= 0.0 && sample_triggers_ <= 0L) {
+    log::warn("Weighter::Weighter",
+              "sample JSON has no or invalid 'pot' or 'triggers'; "
+              "base_event_weight will default to 1");
+  }
+}
+
+ROOT::RDF::RNode Weighter::process(ROOT::RDF::RNode df,
+                                   Origin origin) const {
+  ROOT::RDF::RNode node = df;
+
+  if (origin == Origin::kMonteCarlo || origin == Origin::kDirt) {
+    double scale = 1.0;
+    if (sample_pot_ > 0.0 && total_run_pot_ > 0.0)
+      scale = total_run_pot_ / sample_pot_;
+
+    node = node.Define("base_event_weight", [scale]() { return scale; });
+
+    node = node.Define(
+        "nominal_event_weight",
+        [](double w, float w_spline, float w_tune) {
+          double out = w;
+          if (std::isfinite(w_spline) && w_spline > 0)
+            out *= w_spline;
+          if (std::isfinite(w_tune) && w_tune > 0)
+            out *= w_tune;
+          if (!std::isfinite(out) || out < 0)
+            return 1.0;
+          return out;
+        },
+        {"base_event_weight", "weightSpline", "weightTune"});
+
+  } else if (origin == Origin::kExternal) {
+    double scale = 1.0;
+    if (sample_triggers_ > 0 && total_run_triggers_ > 0) {
+      scale = static_cast<double>(total_run_triggers_) /
+              static_cast<double>(sample_triggers_);
+    }
+    node = node.Define("base_event_weight", [scale]() { return scale; });
+  }
+
+  if (!node.HasColumn("nominal_event_weight")) {
+    if (node.HasColumn("base_event_weight"))
+      node = node.Alias("nominal_event_weight", "base_event_weight");
+    else
+      node = node.Define("nominal_event_weight", []() { return 1.0; });
+  }
+
+  return next_ ? next_->process(node, origin) : node;
+}
+
+}  // namespace faint


### PR DESCRIPTION
## Summary
- convert data-centric headers such as Run, RunReader, Weighter, EventProcessor, Sample, and SampleSet into declarative interfaces only
- move the corresponding implementations into their translation units and flesh out previously stubbed sources
- externalize utility implementations like Variables, Types, and Campaign accessors to keep headers free of inline logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daa21dc06c832e8a2d1c2a00a7188d