### PR TITLE
Add logging utility and refactor sample infrastructure

### DIFF
--- a/include/faint/Campaign.h
+++ b/include/faint/Campaign.h
@@ -14,9 +14,9 @@
 
 #include <faint/Types.h>
 #include <faint/Variables.h>
-#include <faint/data/RunCatalog.h>
-#include <faint/data/Sample.h>
-#include <faint/data/SampleSet.h>
+#include <faint/RunCatalog.h>
+#include <faint/Sample.h>
+#include <faint/SampleSet.h>
 
 namespace faint {
 namespace campaign {
@@ -50,13 +50,17 @@ class Campaign {
 public:
     static Campaign open(const std::string& run_config_json, Options opt, Variables vars = Variables{});
 
-    std::vector<std::string> sample_keys(Origin origin_filter = Origin::kUnknown) const;
+    std::vector<std::string> sample_keys(
+        SampleOrigin origin_filter = SampleOrigin::kUnknown) const;
 
-    ROOT::RDF::RNode df(std::string_view sample_key, Variation v = Variation::kCV) const;
+    ROOT::RDF::RNode df(std::string_view sample_key,
+                        SampleVariation v = SampleVariation::kCV) const;
 
-    ROOT::RDF::RNode final(std::string_view key, Variation v = Variation::kCV) const;
+    ROOT::RDF::RNode final(std::string_view key,
+                           SampleVariation v = SampleVariation::kCV) const;
 
-    ROOT::RDF::RNode quality(std::string_view key, Variation v = Variation::kCV) const;
+    ROOT::RDF::RNode quality(std::string_view key,
+                             SampleVariation v = SampleVariation::kCV) const;
 
     void snapshot_where(const std::string& filter, const std::string& out_file, const std::vector<std::string>& columns = {}) const;
 

--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -5,14 +5,13 @@
 
 #include "ROOT/RDataFrame.hxx"
 
-#include <faint/core/AnalysisKey.h>
-#include <faint/data/SampleTypes.h>
+#include <faint/Types.h>
 
 namespace faint {
 
 struct Dataset {
     SampleOrigin origin_;
-    AnalysisRole role_;
+    SampleRole role_;
     mutable ROOT::RDF::RNode dataframe_;
 };
 

--- a/include/faint/EventProcessor.h
+++ b/include/faint/EventProcessor.h
@@ -13,7 +13,8 @@ class EventProcessor {
 public:
   virtual ~EventProcessor() = default;
 
-  virtual ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const = 0;
+  virtual ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                                   SampleOrigin origin) const = 0;
 
   void chain_processor(std::unique_ptr<EventProcessor> next);
 

--- a/include/faint/Log.h
+++ b/include/faint/Log.h
@@ -1,0 +1,107 @@
+#ifndef FAINT_LOG_H
+#define FAINT_LOG_H
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <iostream>
+
+namespace faint {
+namespace log {
+
+enum class Level { kDebug, kInfo, kWarn, kError };
+
+inline std::mutex& mutex() {
+  static std::mutex m;
+  return m;
+}
+
+inline const char* label(Level level) {
+  switch (level) {
+    case Level::kDebug:
+      return "DEBUG";
+    case Level::kInfo:
+      return "INFO";
+    case Level::kWarn:
+      return "WARN";
+    case Level::kError:
+      return "ERROR";
+  }
+  return "LOG";
+}
+
+template <typename Stream>
+void write_header(Stream& os, Level level, const std::string& scope) {
+  using clock = std::chrono::system_clock;
+  const auto now = clock::now();
+  const std::time_t t = clock::to_time_t(now);
+  std::tm tm{};
+#if defined(_WIN32)
+  localtime_s(&tm, &t);
+#else
+  localtime_r(&t, &tm);
+#endif
+  os << '[' << label(level) << "] " << std::put_time(&tm, "%Y-%m-%d %H:%M:%S") << " | ";
+  if (!scope.empty()) {
+    os << scope << ": ";
+  }
+}
+
+template <typename Stream, typename Arg>
+void append(Stream& os, Arg&& arg) {
+  os << std::forward<Arg>(arg);
+}
+
+template <typename Stream, typename Arg, typename... Args>
+void append(Stream& os, Arg&& arg, Args&&... rest) {
+  os << std::forward<Arg>(arg);
+  if (sizeof...(rest) > 0) os << ' ';
+  append(os, std::forward<Args>(rest)...);
+}
+
+template <typename... Args>
+void log(Level level, const std::string& scope, Args&&... args) {
+  std::lock_guard<std::mutex> lock(mutex());
+  std::ostream& os = (level == Level::kWarn || level == Level::kError)
+                         ? static_cast<std::ostream&>(std::cerr)
+                         : static_cast<std::ostream&>(std::clog);
+  std::ostringstream buffer;
+  append(buffer, std::forward<Args>(args)...);
+  write_header(os, level, scope);
+  os << buffer.str() << '\n';
+}
+
+template <typename... Args>
+[[noreturn]] void fatal(const std::string& scope, Args&&... args) {
+  std::ostringstream buffer;
+  append(buffer, std::forward<Args>(args)...);
+  log(Level::kError, scope, buffer.str());
+  throw std::runtime_error(buffer.str());
+}
+
+template <typename... Args>
+void debug(const std::string& scope, Args&&... args) {
+  log(Level::kDebug, scope, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void info(const std::string& scope, Args&&... args) {
+  log(Level::kInfo, scope, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+void warn(const std::string& scope, Args&&... args) {
+  log(Level::kWarn, scope, std::forward<Args>(args)...);
+}
+
+}  // namespace log
+}  // namespace faint
+
+#endif  // FAINT_LOG_H
+

--- a/include/faint/MuonSelector.h
+++ b/include/faint/MuonSelector.h
@@ -11,7 +11,8 @@ namespace faint {
 
 class MuonSelector : public EventProcessor {
 public:
-  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override;
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                           SampleOrigin origin) const override;
 
 private:
   ROOT::RDF::RNode build_mask(ROOT::RDF::RNode df) const;

--- a/include/faint/PreSelection.h
+++ b/include/faint/PreSelection.h
@@ -12,7 +12,8 @@ namespace faint {
 // previously split across Reconstruction and NuMuCCSelectionProcessor.
 class PreSelection : public EventProcessor {
 public:
-  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override;
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                           SampleOrigin origin) const override;
 };
 
 } // namespace faint

--- a/include/faint/RunCatalog.h
+++ b/include/faint/RunCatalog.h
@@ -1,0 +1,34 @@
+#ifndef FAINT_RUN_CATALOG_H
+#define FAINT_RUN_CATALOG_H
+
+#include <map>
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+#include "faint/Run.h"
+
+namespace faint {
+
+class RunCatalog {
+ public:
+  RunCatalog() = default;
+
+  const Run& get(const std::string& beam, const std::string& period) const;
+
+  const std::map<std::string, Run>& all() const noexcept { return runs_; }
+
+  bool empty() const noexcept { return runs_.empty(); }
+
+  static RunCatalog from_json(const nlohmann::json& data);
+
+  static RunCatalog from_file(const std::string& path);
+
+ private:
+  std::map<std::string, Run> runs_;
+};
+
+}  // namespace faint
+
+#endif  // FAINT_RUN_CATALOG_H
+

--- a/include/faint/Sample.h
+++ b/include/faint/Sample.h
@@ -9,9 +9,9 @@
 #include "ROOT/RDataFrame.hxx"
 #include "nlohmann/json.hpp"
 
-#include <faint/data/IEventProcessor.h>
-#include <faint/data/SampleTypes.h>
-#include <faint/data/VariableRegistry.h>
+#include "faint/EventProcessor.h"
+#include "faint/Types.h"
+#include "faint/Variables.h"
 
 namespace faint {
 
@@ -21,6 +21,17 @@ class Sample {
          const std::string& base_dir, const VariableRegistry& vars,
          IEventProcessor& processor);
 
+  const SampleKey& key() const noexcept { return key_; }
+  SampleOrigin origin() const noexcept { return origin_; }
+  double pot() const noexcept { return pot_; }
+  long triggers() const noexcept { return triggers_; }
+
+  ROOT::RDF::RNode nominal() const { return nominal_node_; }
+  const std::map<SampleVariation, ROOT::RDF::RNode>& variations() const {
+    return variations_;
+  }
+
+ private:
   void validate(const std::string& base_dir) const;
 
   SampleKey key_;
@@ -33,10 +44,8 @@ class Sample {
   double pot_{0.0};
   long triggers_{0};
 
-  ROOT::RDF::RNode node_;
+  ROOT::RDF::RNode nominal_node_;
   std::map<SampleVariation, ROOT::RDF::RNode> variations_;
-
- private:
   std::map<SampleVariation, std::string> variation_paths_;
 
   SampleVariation parse_variation(const std::string& s) const;

--- a/include/faint/SampleSet.h
+++ b/include/faint/SampleSet.h
@@ -9,15 +9,14 @@
 
 #include "ROOT/RDataFrame.hxx"
 
-#include <faint/PreSelection.h>
-#include <faint/Run.h>
-#include <faint/RunReader.h>
-#include <faint/Sample.h>
-#include <faint/TruthClassifier.h>
-#include <faint/Weighter.h>
-#include <faint/core/AnalysisKey.h>
-#include <faint/core/SelectionQuery.h>
-#include <faint/Variables.h>
+#include "faint/PreSelection.h"
+#include "faint/Run.h"
+#include "faint/RunCatalog.h"
+#include "faint/Sample.h"
+#include "faint/SelectionQuery.h"
+#include "faint/TruthClassifier.h"
+#include "faint/Variables.h"
+#include "faint/Weighter.h"
 
 namespace nlohmann {
 class json;
@@ -27,7 +26,7 @@ namespace faint {
 
 class SampleSet {
  public:
-  using Map = std::map<SampleKey, Samples>;
+  using Map = std::map<SampleKey, Sample>;
 
   SampleSet(const RunCatalog& runs, VariableRegistry variables,
             const std::string& beam, std::vector<std::string> periods,

--- a/include/faint/SelectionQuery.h
+++ b/include/faint/SelectionQuery.h
@@ -1,0 +1,25 @@
+#ifndef FAINT_SELECTION_QUERY_H
+#define FAINT_SELECTION_QUERY_H
+
+#include <string>
+#include <utility>
+
+namespace faint {
+
+class SelectionQuery {
+ public:
+  SelectionQuery() = default;
+  explicit SelectionQuery(std::string expression)
+      : expression_(std::move(expression)) {}
+
+  const std::string& str() const noexcept { return expression_; }
+  bool empty() const noexcept { return expression_.empty(); }
+
+ private:
+  std::string expression_;
+};
+
+}  // namespace faint
+
+#endif  // FAINT_SELECTION_QUERY_H
+

--- a/include/faint/TruthClassifier.h
+++ b/include/faint/TruthClassifier.h
@@ -12,10 +12,12 @@ namespace faint {
 
 class TruthClassifier : public EventProcessor {
 public:
-  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override;
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                           SampleOrigin origin) const override;
 
 private:
-  ROOT::RDF::RNode processNonMc(ROOT::RDF::RNode df, Origin origin) const;
+  ROOT::RDF::RNode processNonMc(ROOT::RDF::RNode df,
+                                SampleOrigin origin) const;
   ROOT::RDF::RNode defineCounts(ROOT::RDF::RNode df) const;
   ROOT::RDF::RNode assignInclusiveChannels(ROOT::RDF::RNode df) const;
   ROOT::RDF::RNode assignExclusiveChannels(ROOT::RDF::RNode df) const;

--- a/include/faint/Types.h
+++ b/include/faint/Types.h
@@ -1,29 +1,76 @@
 #ifndef ANALYSIS_TYPES_H
 #define ANALYSIS_TYPES_H
 
+#include <functional>
 #include <string>
+#include <utility>
 
 namespace faint {
 
-enum class Origin : unsigned int { kUnknown = 0, kData, kMonteCarlo, kExternal, kDirt };
-enum class Role { kData, kNominal, kVariation };
+class SampleKey {
+ public:
+  SampleKey() = default;
+  explicit SampleKey(std::string value);
+  SampleKey(const char* value);
 
-enum class Variation : unsigned int {
-    kUnknown = 0,
-    kCV,
-    kLYAttenuation,
-    kLYDown,
-    kLYRayleigh,
-    kRecomb2,
-    kSCE,
-    kWireModX,
-    kWireModYZ,
-    kWireModAngleXZ,
-    kWireModAngleYZ
+  const std::string& str() const noexcept { return value_; }
+  const char* c_str() const noexcept { return value_.c_str(); }
+
+  bool empty() const noexcept { return value_.empty(); }
+
+  friend bool operator==(const SampleKey& lhs, const SampleKey& rhs) noexcept {
+    return lhs.value_ == rhs.value_;
+  }
+
+  friend bool operator!=(const SampleKey& lhs, const SampleKey& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+
+  friend bool operator<(const SampleKey& lhs, const SampleKey& rhs) noexcept {
+    return lhs.value_ < rhs.value_;
+  }
+
+ private:
+  std::string value_;
 };
 
-std::string to_key(Variation var);
+enum class SampleOrigin : unsigned int {
+  kUnknown = 0,
+  kData,
+  kMonteCarlo,
+  kExternal,
+  kDirt
+};
 
-} 
+enum class SampleRole { kData, kNominal, kVariation };
+
+enum class SampleVariation : unsigned int {
+  kUnknown = 0,
+  kCV,
+  kLYAttenuation,
+  kLYDown,
+  kLYRayleigh,
+  kRecomb2,
+  kSCE,
+  kWireModX,
+  kWireModYZ,
+  kWireModAngleXZ,
+  kWireModAngleYZ
+};
+
+std::string to_key(SampleVariation var);
+
+}  // namespace faint
+
+namespace std {
+
+template <>
+struct hash<faint::SampleKey> {
+  std::size_t operator()(const faint::SampleKey& key) const noexcept {
+    return std::hash<std::string>{}(key.str());
+  }
+};
+
+}  // namespace std
 
 #endif

--- a/include/faint/Variables.h
+++ b/include/faint/Variables.h
@@ -22,7 +22,7 @@ class Variables {
 
   static const std::string& single_knob_var();
 
-  static std::vector<std::string> event_var(Origin origin);
+  static std::vector<std::string> event_var(SampleOrigin origin);
 
  private:
   static std::unordered_set<std::string> collect_base_vars();

--- a/include/faint/Weighter.h
+++ b/include/faint/Weighter.h
@@ -14,7 +14,8 @@ public:
   Weighter(const nlohmann::json& cfg, double total_run_pot,
            long total_run_triggers);
 
-  ROOT::RDF::RNode process(ROOT::RDF::RNode df, Origin origin) const override;
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                           SampleOrigin origin) const override;
 
 private:
   double sample_pot_;

--- a/src/MuonSelector.cc
+++ b/src/MuonSelector.cc
@@ -7,7 +7,7 @@
 namespace faint {
 
 ROOT::RDF::RNode MuonSelector::process(ROOT::RDF::RNode df,
-                                       Origin origin) const {
+                                       SampleOrigin origin) const {
   if (!df.HasColumn("track_shower_scores")) {
     auto no_mu_df = df.Define("n_muons_tot", []() { return 0UL; })
                         .Define("has_muon", []() { return false; });

--- a/src/PreSelection.cc
+++ b/src/PreSelection.cc
@@ -7,7 +7,7 @@
 namespace faint {
 
 ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
-                                       Origin origin) const {
+                                       SampleOrigin origin) const {
   ROOT::RDF::RNode node = df;
 
   if (!node.HasColumn("num_slices") && node.HasColumn("nslice"))
@@ -66,7 +66,7 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
         {"pfp_generations"});
   }
 
-  if (origin == Origin::kMonteCarlo) {
+  if (origin == SampleOrigin::kMonteCarlo) {
     if (node.HasColumn("software_trigger_pre_ext")) {
       node = node.Define(
           "software_trigger",
@@ -97,7 +97,8 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
       "pass_pre",
       [origin](float pe_beam, float pe_veto, bool swtrig) {
         const bool dataset_gate =
-            (origin == Origin::kMonteCarlo || origin == Origin::kDirt)
+            (origin == SampleOrigin::kMonteCarlo ||
+             origin == SampleOrigin::kDirt)
                 ? (pe_beam > 0.f && pe_veto < 20.f)
                 : true;
         return dataset_gate && swtrig;

--- a/src/Run.cc
+++ b/src/Run.cc
@@ -3,7 +3,7 @@
 #include <set>
 #include <utility>
 
-#include "faint/utils/Logger.h"
+#include "faint/Log.h"
 
 namespace faint {
 

--- a/src/RunCatalog.cc
+++ b/src/RunCatalog.cc
@@ -1,0 +1,59 @@
+#include "faint/RunCatalog.h"
+
+#include <fstream>
+#include <stdexcept>
+#include <utility>
+
+#include "faint/Log.h"
+
+namespace faint {
+
+namespace {
+
+std::string make_key(const std::string& beam, const std::string& period) {
+  return beam + ":" + period;
+}
+
+}  // namespace
+
+const Run& RunCatalog::get(const std::string& beam,
+                           const std::string& period) const {
+  const auto key = make_key(beam, period);
+  const auto it = runs_.find(key);
+  if (it == runs_.end())
+    throw std::out_of_range("Run not found: " + key);
+  return it->second;
+}
+
+RunCatalog RunCatalog::from_json(const nlohmann::json& data) {
+  RunCatalog catalog;
+  const std::string top =
+      data.contains("run_configurations") ? "run_configurations" : "beamlines";
+  for (const auto& [beam, runs] : data.at(top).items()) {
+    for (const auto& [period, details] : runs.items()) {
+      Run run(details, beam, period);
+      run.validate();
+      const auto key = run.label();
+      if (catalog.runs_.count(key) != 0)
+        log::fatal("RunCatalog::from_json", "Duplicate run label", key);
+      catalog.runs_.emplace(key, std::move(run));
+    }
+  }
+  return catalog;
+}
+
+RunCatalog RunCatalog::from_file(const std::string& path) {
+  std::ifstream input(path);
+  if (!input.is_open())
+    log::fatal("RunCatalog::from_file", "Could not open config file", path);
+  try {
+    const auto data = nlohmann::json::parse(input);
+    return from_json(data);
+  } catch (const std::exception& e) {
+    log::fatal("RunCatalog::from_file", "Parsing error", e.what());
+  }
+  return {};
+}
+
+}  // namespace faint
+

--- a/src/RunReader.cc
+++ b/src/RunReader.cc
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <utility>
 
-#include "faint/utils/Logger.h"
+#include "faint/Log.h"
 
 namespace faint {
 

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include <utility>
 
-#include "faint/utils/Logger.h"
+#include "faint/Log.h"
 
 namespace faint {
 namespace {
@@ -59,7 +59,7 @@ Sample::Sample(const nlohmann::json& j, const nlohmann::json& all,
       exclude_{j.value("exclusion_truth_filters", std::vector<std::string>{})},
       pot_{j.value("pot", 0.0)},
       triggers_{j.value("triggers", 0L)},
-      node_{build(base_dir, vars, processor, path_, all)} {
+      nominal_node_{build(base_dir, vars, processor, path_, all)} {
   if (j.contains("detector_variations")) {
     for (auto& dv : j.at("detector_variations")) {
       SampleVariation dvt =
@@ -80,7 +80,7 @@ void Sample::validate(const std::string& base_dir) const {
   if (key_.str().empty())
     log::fatal("Sample::validate", "empty key_");
   if (origin_ == SampleOrigin::kUnknown)
-    log::fatal("Sample::validate", "unknown  for", key_.str());
+    log::fatal("Sample::validate", "unknown origin for", key_.str());
   if ((origin_ == SampleOrigin::kMonteCarlo || origin_ == SampleOrigin::kDirt) &&
       pot_ <= 0)
     log::fatal("Sample::validate", "invalid pot_ for MC/Dirt", key_.str());

--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -10,8 +10,8 @@
 namespace faint {
 
 ROOT::RDF::RNode TruthClassifier::process(ROOT::RDF::RNode df,
-                                          Origin origin) const {
-  if (origin != Origin::kMonteCarlo) {
+                                          SampleOrigin origin) const {
+  if (origin != SampleOrigin::kMonteCarlo) {
     return this->processNonMc(df, origin);
   }
 
@@ -24,15 +24,15 @@ ROOT::RDF::RNode TruthClassifier::process(ROOT::RDF::RNode df,
 }
 
 ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
-                                               Origin origin) const {
+                                               SampleOrigin origin) const {
   auto mode_df = df.Define("genie_int_mode", []() { return -1; });
 
   auto incl_df = mode_df.Define("incl_channel", [c = origin]() {
-    if (c == Origin::kData)
+    if (c == SampleOrigin::kData)
       return 0;
-    if (c == Origin::kExternal)
+    if (c == SampleOrigin::kExternal)
       return 1;
-    if (c == Origin::kDirt)
+    if (c == SampleOrigin::kDirt)
       return 2;
     return 99;
   });
@@ -41,11 +41,11 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
       incl_df.Define("inclusive_strange_channels", "incl_channel");
 
   auto excl_df = incl_alias_df.Define("excl_channel", [c = origin]() {
-    if (c == Origin::kData)
+    if (c == SampleOrigin::kData)
       return 0;
-    if (c == Origin::kExternal)
+    if (c == SampleOrigin::kExternal)
       return 1;
-    if (c == Origin::kDirt)
+    if (c == SampleOrigin::kDirt)
       return 2;
     return 99;
   });
@@ -54,9 +54,9 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
       excl_df.Define("exclusive_strange_channels", "excl_channel");
 
   auto chan_df = excl_alias_df.Define("channel_def", [c = origin]() {
-    if (c == Origin::kData)
+    if (c == SampleOrigin::kData)
       return 0;
-    if (c == Origin::kExternal || c == Origin::kDirt)
+    if (c == SampleOrigin::kExternal || c == SampleOrigin::kDirt)
       return 1;
     return 99;
   });

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -1,28 +1,34 @@
 #include "faint/Types.h"
 
+#include <utility>
+
 namespace faint {
 
-std::string to_key(Variation var) {
+SampleKey::SampleKey(std::string value) : value_(std::move(value)) {}
+
+SampleKey::SampleKey(const char* value) : value_(value ? value : "") {}
+
+std::string to_key(SampleVariation var) {
   switch (var) {
-    case Variation::kCV:
+    case SampleVariation::kCV:
       return "CV";
-    case Variation::kLYAttenuation:
+    case SampleVariation::kLYAttenuation:
       return "LYAttenuation";
-    case Variation::kLYDown:
+    case SampleVariation::kLYDown:
       return "LYDown";
-    case Variation::kLYRayleigh:
+    case SampleVariation::kLYRayleigh:
       return "LYRayleigh";
-    case Variation::kRecomb2:
+    case SampleVariation::kRecomb2:
       return "Recomb2";
-    case Variation::kSCE:
+    case SampleVariation::kSCE:
       return "SCE";
-    case Variation::kWireModX:
+    case SampleVariation::kWireModX:
       return "WireModX";
-    case Variation::kWireModYZ:
+    case SampleVariation::kWireModYZ:
       return "WireModYZ";
-    case Variation::kWireModAngleXZ:
+    case SampleVariation::kWireModAngleXZ:
       return "WireModAngleXZ";
-    case Variation::kWireModAngleYZ:
+    case SampleVariation::kWireModAngleYZ:
       return "WireModAngleYZ";
     default:
       return "Unknown";

--- a/src/Variables.cc
+++ b/src/Variables.cc
@@ -34,9 +34,9 @@ const std::string& Variables::single_knob_var() {
   return s;
 }
 
-std::vector<std::string> Variables::event_var(Origin origin) {
+std::vector<std::string> Variables::event_var(SampleOrigin origin) {
   auto vars = collect_base_vars();
-  if (origin == Origin::kMonteCarlo || origin == Origin::kDirt)
+  if (origin == SampleOrigin::kMonteCarlo || origin == SampleOrigin::kDirt)
     add_mc_vars(vars);
   return std::vector<std::string>(vars.begin(), vars.end());
 }

--- a/src/Weighter.cc
+++ b/src/Weighter.cc
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#include "faint/utils/Logger.h"
+#include "faint/Log.h"
 
 namespace faint {
 
@@ -20,10 +20,10 @@ Weighter::Weighter(const nlohmann::json& cfg, double total_run_pot,
 }
 
 ROOT::RDF::RNode Weighter::process(ROOT::RDF::RNode df,
-                                   Origin origin) const {
+                                   SampleOrigin origin) const {
   ROOT::RDF::RNode node = df;
 
-  if (origin == Origin::kMonteCarlo || origin == Origin::kDirt) {
+  if (origin == SampleOrigin::kMonteCarlo || origin == SampleOrigin::kDirt) {
     double scale = 1.0;
     if (sample_pot_ > 0.0 && total_run_pot_ > 0.0)
       scale = total_run_pot_ / sample_pot_;
@@ -44,7 +44,7 @@ ROOT::RDF::RNode Weighter::process(ROOT::RDF::RNode df,
         },
         {"base_event_weight", "weightSpline", "weightTune"});
 
-  } else if (origin == Origin::kExternal) {
+  } else if (origin == SampleOrigin::kExternal) {
     double scale = 1.0;
     if (sample_triggers_ > 0 && total_run_triggers_ > 0) {
       scale = static_cast<double>(total_run_triggers_) /


### PR DESCRIPTION
## Summary
- add a lightweight header-only logging helper and update all data components to use it instead of the removed utils logger
- introduce a RunCatalog wrapper around run metadata and rework Campaign/SampleSet to consume the new API and modernized type system
- refresh Sample, SampleSet, Variables, Weighter, and related headers to expose consistent FAINT types and selection helpers

## Testing
- `make -C build` *(fails: missing ROOT headers in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa70b4c4c832e8a7d3dc244ef6f10