### PR TITLE
Silence unused variable warning in Sample::build

### DIFF
--- a/include/faint/Sample.h
+++ b/include/faint/Sample.h
@@ -49,7 +49,8 @@ class Sample {
   std::map<SampleVariation, std::string> variation_paths_;
 
   SampleVariation parse_variation(const std::string& s) const;
-  ROOT::RDF::RNode build(const std::string& base_dir, const VariableRegistry& vars,
+  ROOT::RDF::RNode build(const std::string& base_dir,
+                         [[maybe_unused]] const VariableRegistry& vars,
                          EventProcessor& processor, const std::string& rel,
                          const nlohmann::json& all);
 };

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -118,7 +118,7 @@ SampleVariation Sample::parse_variation(const std::string& s) const {
 }
 
 ROOT::RDF::RNode Sample::build(const std::string& base_dir,
-                               const VariableRegistry& vars,
+                               [[maybe_unused]] const VariableRegistry& vars,
                                EventProcessor& processor,
                                const std::string& rel,
                                const nlohmann::json& all) {


### PR DESCRIPTION
## Summary
- mark the Sample::build VariableRegistry parameter as [[maybe_unused]] to prevent compiler warnings
- update both the declaration and definition to match

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab34e227c832e8b793b063d2518ac