### PR TITLE
Remove redundant ROOT dictionary translation unit

### DIFF
--- a/src/faintLinkDef.cc
+++ b/src/faintLinkDef.cc
@@ -1,3 +1,0 @@
-#include "faintLinkDef.h"
-
-// Translation unit generated to accompany the ROOT dictionary header.


### PR DESCRIPTION
## Summary
- remove the no-op `faintLinkDef.cc` translation unit that only included the ROOT dictionary header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab4391390832eb770202b2216eb9a