### PR TITLE
Allow example macro to accept run configuration

### DIFF
--- a/include/faint/Campaign.h
+++ b/include/faint/Campaign.h
@@ -39,6 +39,8 @@ std::string run_config_path();
 
 std::string ntuple_directory();
 
+std::string ntuple_directory(const std::string& run_config_json);
+
 struct Options {
     std::string beam;
     std::vector<std::string> periods;

--- a/src/Campaign.cc
+++ b/src/Campaign.cc
@@ -19,7 +19,11 @@ std::string run_config_path() {
 }
 
 std::string ntuple_directory() {
-    const auto config_path = run_config_path();
+    return ntuple_directory(run_config_path());
+}
+
+std::string ntuple_directory(const std::string& run_config_json) {
+    const auto& config_path = run_config_json;
     std::ifstream input(config_path);
     if (!input.is_open()) {
         throw std::runtime_error("Could not open run configuration: " + config_path);

--- a/src/example_macro.C
+++ b/src/example_macro.C
@@ -7,18 +7,23 @@
 
 #include <faint/Campaign.h>
 
-void example_macro()
+void example_macro(const char* run_config = nullptr)
 {
   if (gSystem->Load("libfaint_root")) {
     throw std::runtime_error("Failed to load libfaint_root library");
   }
 
+  std::string config_path = run_config ? run_config : "";
+  if (config_path.empty()) {
+    config_path = faint::campaign::run_config_path();
+  }
+
   faint::campaign::Options options;
   options.beam = "numi-fhc";
   options.periods = {"run1"};
-  options.ntuple_dir = faint::campaign::ntuple_directory();
+  options.ntuple_dir = faint::campaign::ntuple_directory(config_path);
 
-  auto campaign = faint::campaign::Campaign::open(faint::campaign::run_config_path(), options);
+  auto campaign = faint::campaign::Campaign::open(config_path, options);
 
   std::cout << "Loaded beam " << campaign.beam() << " for";
   for (const auto& p : campaign.periods()) {


### PR DESCRIPTION
## Summary
- allow the example ROOT macro to accept an optional run configuration path and load samples from it
- expose a helper overload so callers can look up the ntuple directory for a specific configuration file

## Testing
- cmake --build build *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_68dae1e1e9d4832e932d8047382b90f3