### PR TITLE
Fix truth classifier fiducial check for float branches

### DIFF
--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -69,7 +69,7 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
 ROOT::RDF::RNode TruthClassifier::defineCounts(ROOT::RDF::RNode df) const {
   auto fid_df = df.Define(
       "in_fiducial",
-      [](double x, double y, double z) {
+      [](const auto& x, const auto& y, const auto& z) {
         return fiducial::is_in_truth_volume(x, y, z);
       },
       {"neutrino_vertex_x", "neutrino_vertex_y", "neutrino_vertex_z"});


### PR DESCRIPTION
## Summary
- adapt the TruthClassifier fiducial volume lambda to accept the branch-native types so ROOT does not try to read float branches as doubles

## Testing
- `./scripts/faint-root.sh -b -q src/example_macro.C` *(fails: `root` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae73dccf4832ebbfa228b5edb5a51