### PR TITLE
Fix fiducial lambda signature for ROOT Define

### DIFF
--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -69,7 +69,7 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
 ROOT::RDF::RNode TruthClassifier::defineCounts(ROOT::RDF::RNode df) const {
   auto fid_df = df.Define(
       "in_fiducial",
-      [](double x, double y, double z) {
+      [](float x, float y, float z) {
         return fiducial::is_in_truth_volume(x, y, z);
       },
       {"neutrino_vertex_x", "neutrino_vertex_y", "neutrino_vertex_z"});


### PR DESCRIPTION
## Summary
- change the fiducial volume Define lambda to accept float arguments so ROOT matches the branch types

## Testing
- `cmake --build build` *(fails: build cache not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dae73dccf4832ebbfa228b5edb5a51