### PR TITLE
Enable implicit multithreading in example macro

### DIFF
--- a/src/example_macro.C
+++ b/src/example_macro.C
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "TSystem.h"
+#include "ROOT/RDataFrame.hxx"
 
 #include <faint/Campaign.h>
 
@@ -17,6 +18,8 @@ void example_macro(const char* run_config = nullptr)
   if (config_path.empty()) {
     config_path = faint::campaign::run_config_path();
   }
+
+  ROOT::EnableImplicitMT();
 
   faint::campaign::Options options;
   options.beam = "numi-fhc";


### PR DESCRIPTION
## Summary
- enable ROOT implicit multithreading in the example macro to speed up Count() evaluation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbbcf8d544832eb008c0d14b2df3b2