### PR TITLE
Precompute final selection count in example macro

### DIFF
--- a/src/example_macro.C
+++ b/src/example_macro.C
@@ -36,7 +36,8 @@ void example_macro(const char* run_config = nullptr)
 
   for (const auto& key : campaign.sample_keys()) {
     auto final_count = campaign.final(key).Count();
-    std::cout << "Final selection entries for " << key << ": " << final_count.GetValue() << std::endl;
+    auto final_count_value = final_count.GetValue();
+    std::cout << "Final selection entries for " << key << ": " << final_count_value << std::endl;
   }
 
   std::cout << "Total POT: " << campaign.pot() << std::endl;


### PR DESCRIPTION
## Summary
- store the final selection count value in a temporary variable before logging it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbe5d8d40832e8c463e779ab5d091