### PR TITLE
Restore example macro entry point

### DIFF
--- a/src/example_macro.C
+++ b/src/example_macro.C
@@ -1,33 +1,49 @@
 #include <ROOT/RDataFrame.hxx>
-#include <faint/Dataset.h>
+#include <ROOT/RDFHelpers.hxx>
+#include <TSystem.h>
+#include <faint/Campaign.h>
 #include <faint/Log.h>
 
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
-int main(int argc, char** argv) {
-  faint::log::init();
-  faint::log::set_level(faint::log::Level::kDebug);
+void example_macro() {
+  try {
+    faint::log::init();
+    faint::log::set_level(faint::log::Level::kDebug);
 
-  std::string config_path;
-  if (argc > 1) {
-    config_path = argv[1];
-  } else {
-    config_path = faint::dataset::run_config_path();
+    ROOT::EnableImplicitMT();
+
+    if (gSystem->Load("libfaint_root")) {
+      throw std::runtime_error("Failed to load libfaint_root library");
+    }
+
+    const std::string config_path = "data/samples.json";
+
+    faint::campaign::Options options;
+    options.beam = "numi-fhc";
+    options.periods = {"run1"};
+    options.ntuple_dir = faint::campaign::ntuple_directory();
+
+    auto campaign = faint::campaign::Campaign::open(config_path, options);
+
+    std::cout << "Loaded beam " << campaign.beam() << " for";
+    for (const auto& period : campaign.periods()) {
+      std::cout << ' ' << period;
+    }
+    std::cout << " with " << campaign.sample_keys().size() << " samples." << std::endl;
+
+    for (const auto& key : campaign.sample_keys()) {
+      auto final_count = campaign.final(key).Count();
+      std::cout << "Final selection entries for " << key << ": " << final_count.GetValue()
+                << std::endl;
+    }
+
+    std::cout << "Total POT: " << campaign.pot() << std::endl;
+    std::cout << "Total triggers: " << campaign.triggers() << std::endl;
+  } catch (const std::exception& ex) {
+    std::cerr << "Error: " << ex.what() << std::endl;
   }
-
-  faint::dataset::Options options;
-  options.ntuple_dir = faint::dataset::ntuple_directory(config_path);
-  auto dataset = faint::dataset::Dataset::open(config_path, options);
-
-  auto keys = dataset.sample_keys();
-  std::cout << "Loaded the following samples:\n";
-  for (const auto& key : keys) {
-    std::cout << "  - " << key << '\n';
-  }
-
-  auto df = dataset.df(keys.at(0));
-  auto count = df.Count();
-  std::cout << "Count of rows: " << *count << '\n';
-
-  return 0;
 }


### PR DESCRIPTION
## Summary
- restore the example macro entry point instead of using a main function
- hardcode the campaign configuration path to data/samples.json while keeping multithreading enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc21f17c4832e8a77b8640269373e