### PR TITLE
Add reusable stacked histogram plotting helper

### DIFF
--- a/include/faint/StackedHistogram.h
+++ b/include/faint/StackedHistogram.h
@@ -1,0 +1,124 @@
+#ifndef FAINT_STACKED_HISTOGRAM_H
+#define FAINT_STACKED_HISTOGRAM_H
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Rtypes.h"
+#include "TColor.h"
+
+class TCanvas;
+class TH1;
+class TObject;
+
+namespace faint {
+namespace plot {
+
+class StackedHistogram {
+ public:
+  enum class CutDirection { kLessThan, kGreaterThan };
+
+  struct Cut {
+    double threshold{0.0};
+    CutDirection direction{CutDirection::kGreaterThan};
+    std::string label{};
+    Color_t color{kRed};
+  };
+
+  StackedHistogram(std::string plot_name, std::string output_directory = "plots");
+  ~StackedHistogram();
+
+  void setXAxisTitle(std::string title);
+  void setYAxisTitle(std::string title);
+  void setLogY(bool value);
+  void setYAxisRange(double minimum, double maximum);
+  void resetYAxisRange();
+
+  void setLegendPosition(double x1, double y1, double x2, double y2);
+  void setLegendColumns(int columns);
+  void setLegendTextSize(double size);
+  void setLegendHeader(std::optional<std::string> header);
+
+  void setAnnotateYields(bool value);
+
+  void addBackground(const TH1& hist, std::string label, Color_t color,
+                     Style_t fill_style = 1001);
+  void clearBackgrounds();
+
+  void setData(const TH1& hist, std::string label = "Data",
+               Color_t color = kBlack, Style_t marker_style = 20);
+  void clearData();
+
+  void setSignal(const TH1& hist, std::string label,
+                 Color_t color = kGreen + 2, Style_t line_style = kDashed,
+                 double scale = 1.0, int line_width = 2);
+  void clearSignal();
+
+  void addCut(double threshold, CutDirection direction,
+              std::string label = std::string(), Color_t color = kRed);
+  void clearCuts();
+
+  void draw(TCanvas& canvas);
+  void drawAndSave(const std::string& format = "png");
+
+ private:
+  struct BackgroundComponent {
+    std::string label;
+    std::unique_ptr<TH1> histogram;
+    Color_t color{kGray + 1};
+    Style_t fill_style{1001};
+  };
+
+  struct DataComponent {
+    std::string label;
+    std::unique_ptr<TH1> histogram;
+    Color_t color{kBlack};
+    Style_t marker_style{20};
+  };
+
+  struct SignalComponent {
+    std::string label;
+    std::unique_ptr<TH1> histogram;
+    Color_t color{kGreen + 2};
+    Style_t line_style{kDashed};
+    double scale{1.0};
+    int line_width{2};
+  };
+
+  std::unique_ptr<TH1> cloneHistogram(const TH1& hist,
+                                       const std::string& suffix) const;
+  std::string formatYield(double value, int precision = 1) const;
+  void setGlobalStyle() const;
+  void drawCuts(double max_y, double x_min, double x_max);
+
+  std::string plot_name_;
+  std::string output_directory_;
+  std::string x_axis_title_;
+  std::string y_axis_title_{"Events"};
+  bool use_log_y_{false};
+  bool has_y_range_{false};
+  double y_min_{0.0};
+  double y_max_{0.0};
+  double legend_x1_{0.62};
+  double legend_y1_{0.6};
+  double legend_x2_{0.88};
+  double legend_y2_{0.88};
+  int legend_columns_{1};
+  double legend_text_size_{0.04};
+  std::optional<std::string> legend_header_{};
+  bool annotate_yields_{true};
+
+  std::vector<BackgroundComponent> backgrounds_;
+  std::optional<DataComponent> data_;
+  std::optional<SignalComponent> signal_;
+  std::vector<Cut> cuts_;
+  std::vector<std::unique_ptr<TObject>> overlays_;
+};
+
+}  // namespace plot
+}  // namespace faint
+
+#endif  // FAINT_STACKED_HISTOGRAM_H

--- a/src/StackedHistogram.cc
+++ b/src/StackedHistogram.cc
@@ -1,0 +1,415 @@
+#include "faint/StackedHistogram.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#include "TArrow.h"
+#include "TCanvas.h"
+#include "TImage.h"
+#include "TLegend.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TH1.h"
+#include "THStack.h"
+
+#include "faint/Log.h"
+#include "faint/PlotStyle.h"
+
+namespace faint {
+namespace plot {
+
+namespace {
+constexpr double kDefaultCanvasWidth = 800;
+constexpr double kDefaultCanvasHeight = 600;
+}  // namespace
+
+StackedHistogram::StackedHistogram(std::string plot_name,
+                                   std::string output_directory)
+    : plot_name_(std::move(plot_name)),
+      output_directory_(std::move(output_directory)) {}
+
+StackedHistogram::~StackedHistogram() = default;
+
+void StackedHistogram::setXAxisTitle(std::string title) {
+  x_axis_title_ = std::move(title);
+}
+
+void StackedHistogram::setYAxisTitle(std::string title) {
+  y_axis_title_ = std::move(title);
+}
+
+void StackedHistogram::setLogY(bool value) { use_log_y_ = value; }
+
+void StackedHistogram::setYAxisRange(double minimum, double maximum) {
+  has_y_range_ = true;
+  y_min_ = minimum;
+  y_max_ = maximum;
+}
+
+void StackedHistogram::resetYAxisRange() { has_y_range_ = false; }
+
+void StackedHistogram::setLegendPosition(double x1, double y1, double x2,
+                                         double y2) {
+  legend_x1_ = x1;
+  legend_y1_ = y1;
+  legend_x2_ = x2;
+  legend_y2_ = y2;
+}
+
+void StackedHistogram::setLegendColumns(int columns) {
+  legend_columns_ = std::max(1, columns);
+}
+
+void StackedHistogram::setLegendTextSize(double size) { legend_text_size_ = size; }
+
+void StackedHistogram::setLegendHeader(std::optional<std::string> header) {
+  legend_header_ = std::move(header);
+}
+
+void StackedHistogram::setAnnotateYields(bool value) { annotate_yields_ = value; }
+
+void StackedHistogram::addBackground(const TH1& hist, std::string label,
+                                     Color_t color, Style_t fill_style) {
+  std::string suffix = label.empty() ? "background" : label;
+  std::transform(suffix.begin(), suffix.end(), suffix.begin(), [](unsigned char ch) {
+    return (std::isalnum(ch) || ch == '_') ? static_cast<char>(ch) : '_';
+  });
+  suffix += "_" + std::to_string(backgrounds_.size());
+
+  backgrounds_.push_back(BackgroundComponent{std::move(label),
+                                             cloneHistogram(hist, suffix), color,
+                                             fill_style});
+}
+
+void StackedHistogram::clearBackgrounds() { backgrounds_.clear(); }
+
+void StackedHistogram::setData(const TH1& hist, std::string label, Color_t color,
+                               Style_t marker_style) {
+  data_ = DataComponent{std::move(label), cloneHistogram(hist, "data"), color,
+                        marker_style};
+}
+
+void StackedHistogram::clearData() { data_.reset(); }
+
+void StackedHistogram::setSignal(const TH1& hist, std::string label,
+                                 Color_t color, Style_t line_style,
+                                 double scale, int line_width) {
+  signal_ = SignalComponent{std::move(label), cloneHistogram(hist, "signal"),
+                            color, line_style, scale, line_width};
+}
+
+void StackedHistogram::clearSignal() { signal_.reset(); }
+
+void StackedHistogram::addCut(double threshold, CutDirection direction,
+                              std::string label, Color_t color) {
+  cuts_.push_back(Cut{threshold, direction, std::move(label), color});
+}
+
+void StackedHistogram::clearCuts() { cuts_.clear(); }
+
+void StackedHistogram::draw(TCanvas& canvas) {
+  setGlobalStyle();
+
+  canvas.cd();
+  canvas.Clear();
+  canvas.SetLogy(use_log_y_);
+
+  overlays_.clear();
+
+  THStack stack((plot_name_ + "_stack").c_str(), plot_name_.c_str());
+
+  std::vector<BackgroundComponent*> ordered_backgrounds;
+  ordered_backgrounds.reserve(backgrounds_.size());
+  for (auto& background : backgrounds_) {
+    ordered_backgrounds.push_back(&background);
+  }
+
+  std::stable_sort(ordered_backgrounds.begin(), ordered_backgrounds.end(),
+                   [](const BackgroundComponent* lhs,
+                      const BackgroundComponent* rhs) {
+                     return lhs->histogram->Integral() <
+                            rhs->histogram->Integral();
+                   });
+  std::reverse(ordered_backgrounds.begin(), ordered_backgrounds.end());
+
+  double max_y = 0.0;
+  for (auto* component : ordered_backgrounds) {
+    auto* hist = component->histogram.get();
+    hist->SetDirectory(nullptr);
+    hist->SetFillColor(component->color);
+    hist->SetFillStyle(component->fill_style);
+    hist->SetLineColor(kBlack);
+    hist->SetLineWidth(1);
+    stack.Add(hist, "HIST");
+    max_y = std::max(max_y, hist->GetMaximum());
+  }
+
+  bool drew_stack = !ordered_backgrounds.empty();
+  if (drew_stack) {
+    stack.Draw("HIST");
+  } else if (data_) {
+    data_->histogram->Draw("E1");
+    max_y = std::max(max_y, data_->histogram->GetMaximum());
+  } else if (signal_) {
+    signal_->histogram->Draw("HIST");
+    max_y = std::max(max_y, signal_->histogram->GetMaximum());
+  } else {
+    faint::log::warn("StackedHistogram::draw", "No histograms available to draw");
+    canvas.Update();
+    return;
+  }
+
+  TH1* frame = drew_stack ? stack.GetHistogram() : nullptr;
+  if (!frame) {
+    frame = drew_stack ? ordered_backgrounds.front()->histogram.get()
+                       : data_ ? data_->histogram.get()
+                               : signal_ ? signal_->histogram.get() : nullptr;
+  }
+
+  double total_background_yield = 0.0;
+  for (auto* component : ordered_backgrounds) {
+    total_background_yield += component->histogram->Integral(0, component->histogram->GetNbinsX() + 1);
+  }
+
+  if (frame) {
+    frame->GetXaxis()->SetTitle(x_axis_title_.c_str());
+    frame->GetYaxis()->SetTitle(y_axis_title_.c_str());
+    frame->GetXaxis()->SetTitleOffset(1.1);
+    frame->GetYaxis()->SetTitleOffset(1.2);
+    frame->GetXaxis()->SetLabelSize(0.045);
+    frame->GetYaxis()->SetLabelSize(0.045);
+    frame->GetXaxis()->SetTitleSize(0.05);
+    frame->GetYaxis()->SetTitleSize(0.05);
+  }
+
+  double dynamic_max = max_y;
+
+  if (signal_) {
+    auto* hist = signal_->histogram.get();
+    const double scale = signal_->scale;
+    if (scale != 1.0) {
+      hist->Scale(scale);
+    }
+    hist->SetLineColor(signal_->color);
+    hist->SetLineStyle(signal_->line_style);
+    hist->SetLineWidth(signal_->line_width);
+    hist->SetFillStyle(0);
+    hist->Draw("HIST SAME");
+    dynamic_max = std::max(dynamic_max, hist->GetMaximum());
+    if (scale != 1.0) {
+      hist->Scale(1.0 / scale);
+    }
+  }
+
+  if (data_) {
+    auto* hist = data_->histogram.get();
+    hist->SetLineColor(data_->color);
+    hist->SetMarkerColor(data_->color);
+    hist->SetMarkerStyle(data_->marker_style);
+    hist->SetLineWidth(1);
+    hist->Draw("E1 SAME");
+    dynamic_max = std::max(dynamic_max, hist->GetMaximum());
+  }
+
+  double y_min = use_log_y_ ? 0.1 : 0.0;
+  double y_max = dynamic_max > 0.0
+                      ? dynamic_max * (use_log_y_ ? 10.0 : 1.25)
+                      : (use_log_y_ ? 10.0 : 1.0);
+
+  if (has_y_range_) {
+    y_min = y_min_;
+    y_max = y_max_;
+  }
+
+  if (frame) {
+    frame->SetMinimum(y_min);
+    frame->SetMaximum(y_max);
+  } else if (data_) {
+    data_->histogram->GetYaxis()->SetRangeUser(y_min, y_max);
+  }
+
+  auto legend = std::make_unique<TLegend>(legend_x1_, legend_y1_, legend_x2_, legend_y2_);
+  legend->SetBorderSize(0);
+  legend->SetFillStyle(0);
+  legend->SetNColumns(legend_columns_);
+  legend->SetTextSize(legend_text_size_);
+  if (legend_header_) {
+    legend->SetHeader(legend_header_->c_str(), "C");
+  }
+
+  auto make_label = [&](const std::string& base_label, double yield) {
+    if (!annotate_yields_) {
+      return base_label;
+    }
+    std::ostringstream ss;
+    ss << base_label;
+    if (!base_label.empty()) {
+      ss << " ";
+    }
+    ss << formatYield(yield, 2);
+    return ss.str();
+  };
+
+  for (auto* component : ordered_backgrounds) {
+    legend->AddEntry(component->histogram.get(),
+                     make_label(component->label,
+                                component->histogram->Integral(0, component->histogram->GetNbinsX() + 1))
+                         .c_str(),
+                     "f");
+  }
+
+  if (signal_) {
+    legend->AddEntry(signal_->histogram.get(),
+                     make_label(signal_->label,
+                                signal_->histogram->Integral(0, signal_->histogram->GetNbinsX() + 1))
+                         .c_str(),
+                     "l");
+  }
+
+  if (data_) {
+    legend->AddEntry(data_->histogram.get(),
+                     make_label(data_->label,
+                                data_->histogram->Integral(0, data_->histogram->GetNbinsX() + 1))
+                         .c_str(),
+                     "lep");
+  }
+
+  legend->Draw();
+  overlays_.push_back(std::unique_ptr<TObject>(legend.release()));
+
+  if (frame) {
+    drawCuts(y_max, frame->GetXaxis()->GetXmin(), frame->GetXaxis()->GetXmax());
+  }
+
+  if (drew_stack) {
+    stack.SetMaximum(y_max);
+    stack.SetMinimum(y_min);
+  }
+
+  if (frame) {
+    std::ostringstream title;
+    title << plot_name_;
+    if (annotate_yields_ && total_background_yield > 0.0) {
+      title << " (Bkg: " << formatYield(total_background_yield, 2) << ")";
+    }
+    const std::string text = title.str();
+    auto watermark = std::make_unique<TLatex>(canvas.GetLeftMargin() + 0.01,
+                                              1.0 - canvas.GetTopMargin() + 0.01,
+                                              text.c_str());
+    watermark->SetNDC();
+    watermark->SetTextFont(62);
+    watermark->SetTextSize(0.045);
+    watermark->SetTextAlign(13);
+    watermark->Draw();
+    overlays_.push_back(std::unique_ptr<TObject>(watermark.release()));
+  }
+
+  canvas.RedrawAxis();
+  canvas.Update();
+}
+
+void StackedHistogram::drawAndSave(const std::string& format) {
+  setGlobalStyle();
+  gROOT->SetBatch(kTRUE);
+  if (gSystem) {
+    gSystem->mkdir(output_directory_.c_str(), true);
+  }
+
+  TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(),
+                 static_cast<int>(kDefaultCanvasWidth),
+                 static_cast<int>(kDefaultCanvasHeight));
+
+  draw(canvas);
+
+  const std::string out_path = output_directory_ + "/" + plot_name_ + "." + format;
+  if (format == "pdf") {
+    canvas.SaveAs(out_path.c_str());
+  } else {
+    std::unique_ptr<TImage> image(TImage::Create());
+    if (!image) {
+      faint::log::warn("StackedHistogram::drawAndSave", "Failed to create ROOT image object");
+      return;
+    }
+    image->FromPad(&canvas);
+    image->WriteImage(out_path.c_str());
+  }
+}
+
+std::unique_ptr<TH1> StackedHistogram::cloneHistogram(const TH1& hist,
+                                                       const std::string& suffix) const {
+  std::string base_name = hist.GetName();
+  if (base_name.empty()) {
+    base_name = plot_name_;
+  }
+  std::string clone_name = base_name + "_" + suffix;
+  TObject* cloned = hist.Clone(clone_name.c_str());
+  auto* cloned_hist = dynamic_cast<TH1*>(cloned);
+  if (!cloned_hist) {
+    throw std::runtime_error("Failed to clone histogram for stacked plot");
+  }
+  cloned_hist->SetDirectory(nullptr);
+  return std::unique_ptr<TH1>(cloned_hist);
+}
+
+std::string StackedHistogram::formatYield(double value, int precision) const {
+  std::ostringstream ss;
+  ss.setf(std::ios::fixed);
+  ss.precision(precision);
+  ss << value;
+  return ss.str();
+}
+
+void StackedHistogram::setGlobalStyle() const {
+  faint::plot::apply_plot_style();
+}
+
+void StackedHistogram::drawCuts(double max_y, double x_min, double x_max) {
+  if (cuts_.empty()) {
+    return;
+  }
+
+  const double y_for_arrow = max_y * 0.85;
+  const double arrow_length = (x_max - x_min) * 0.04;
+
+  for (const auto& cut : cuts_) {
+    auto line = std::make_unique<TLine>(cut.threshold, 0.0, cut.threshold, max_y);
+    line->SetLineColor(cut.color);
+    line->SetLineWidth(2);
+    line->SetLineStyle(kDashed);
+    line->Draw("same");
+
+    double x_end = cut.direction == CutDirection::kGreaterThan
+                       ? cut.threshold + arrow_length
+                       : cut.threshold - arrow_length;
+
+    auto arrow = std::make_unique<TArrow>(cut.threshold, y_for_arrow, x_end,
+                                          y_for_arrow, 0.02, ">");
+    arrow->SetLineColor(cut.color);
+    arrow->SetFillColor(cut.color);
+    arrow->SetLineWidth(2);
+    arrow->Draw("same");
+
+    overlays_.push_back(std::unique_ptr<TObject>(line.release()));
+    overlays_.push_back(std::unique_ptr<TObject>(arrow.release()));
+
+    if (!cut.label.empty()) {
+      auto text = std::make_unique<TLatex>(cut.threshold, max_y * 1.02,
+                                          cut.label.c_str());
+      text->SetTextAlign(21);
+      text->SetTextFont(42);
+      text->SetTextSize(0.04);
+      text->Draw();
+      overlays_.push_back(std::unique_ptr<TObject>(text.release()));
+    }
+  }
+}
+
+}  // namespace plot
+}  // namespace faint


### PR DESCRIPTION
## Summary
- add a faint::plot::StackedHistogram helper that wraps ROOT drawing calls for stacked histograms, legends, and optional cut markers
- provide drawAndSave() utility that prepares the canvas, applies project styling, and exports image or PDF outputs

## Testing
- make -C build *(fails: ROOT headers such as ROOT/RDataFrame.hxx are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc85fb8f8832e927e2e7c3395fecf