### PR TITLE
Update example macro to use dataset API directly

### DIFF
--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -1,7 +1,7 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
 #include <TSystem.h>
-#include <faint/Campaign.h>
+#include <faint/Dataset.h>
 #include <faint/Log.h>
 
 #include <iostream>
@@ -22,27 +22,27 @@ void example_macro() {
 
     const std::string config_path = "data/samples.json";
 
-    faint::campaign::Options options;
+    faint::dataset::Options options;
     options.beam = "numi-fhc";
     options.periods = {"run1"};
-    options.ntuple_dir = faint::campaign::ntuple_directory();
+    options.ntuple_dir = faint::dataset::ntuple_directory();
 
-    auto campaign = faint::campaign::Campaign::open(config_path, options);
+    auto dataset = faint::dataset::Dataset::open(config_path, options);
 
-    std::cout << "Loaded beam " << campaign.beam() << " for";
-    for (const auto& period : campaign.periods()) {
+    std::cout << "Loaded beam " << dataset.beam() << " for";
+    for (const auto& period : dataset.periods()) {
       std::cout << ' ' << period;
     }
-    std::cout << " with " << campaign.sample_keys().size() << " samples." << std::endl;
+    std::cout << " with " << dataset.sample_keys().size() << " samples." << std::endl;
 
-    for (const auto& key : campaign.sample_keys()) {
-      auto final_count = campaign.final(key).Count();
+    for (const auto& key : dataset.sample_keys()) {
+      auto final_count = dataset.final(key).Count();
       std::cout << "Final selection entries for " << key << ": " << final_count.GetValue()
                 << std::endl;
     }
 
-    std::cout << "Total POT: " << campaign.pot() << std::endl;
-    std::cout << "Total triggers: " << campaign.triggers() << std::endl;
+    std::cout << "Total POT: " << dataset.pot() << std::endl;
+    std::cout << "Total triggers: " << dataset.triggers() << std::endl;
   } catch (const std::exception& ex) {
     std::cerr << "Error: " << ex.what() << std::endl;
   }


### PR DESCRIPTION
## Summary
- remove the example macro's dependency on the deprecated Campaign wrapper
- include the dataset API directly to open samples and report statistics

## Testing
- not run (example macro change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbc9555118832ea0d70737c72379eb