### PR TITLE
Remove deprecated TruthChannelProcessor alias

### DIFF
--- a/include/faint/TruthClassifier.h
+++ b/include/faint/TruthClassifier.h
@@ -24,9 +24,6 @@ private:
   ROOT::RDF::RNode assignChannelDefinitions(ROOT::RDF::RNode df) const;
 };
 
-// ---------- Backward-compat (remove when migrated) ----------
-using TruthChannelProcessor = TruthClassifier;
-
 } // namespace faint
 
 #endif


### PR DESCRIPTION
## Summary
- remove the TruthChannelProcessor compatibility alias and associated comment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc9e1745c832e93783bb1690d787e