### PR TITLE
Define muon track selection thresholds in header

### DIFF
--- a/include/faint/Selections.h
+++ b/include/faint/Selections.h
@@ -34,6 +34,14 @@ struct TopologyCut {
   static constexpr float kMinClusterFraction = 0.5f;
 };
 
+struct MuonTrackCut {
+  static constexpr float kMinScore = 0.5f;
+  static constexpr float kMinLLR = 0.2f;
+  static constexpr float kMinLength = 10.0f;
+  static constexpr float kMaxDistance = 4.0f;
+  static constexpr unsigned kRequiredGeneration = 2u;
+};
+
 inline bool passes_pre_selection(SampleOrigin origin, float pe_beam,
                                  float pe_veto, bool software_trigger) {
   const bool requires_dataset_gate =
@@ -64,6 +72,17 @@ inline bool passes_topology_selection(float contained_fraction,
                                       float cluster_fraction) {
   return contained_fraction >= TopologyCut::kMinContainedFraction &&
          cluster_fraction >= TopologyCut::kMinClusterFraction;
+}
+
+inline bool passes_muon_track_selection(float score, float llr, float length,
+                                        float distance, unsigned generation,
+                                        bool fid_start, bool fid_end) {
+  return score > MuonTrackCut::kMinScore &&
+         llr > MuonTrackCut::kMinLLR &&
+         length > MuonTrackCut::kMinLength &&
+         distance < MuonTrackCut::kMaxDistance &&
+         generation == MuonTrackCut::kRequiredGeneration && fid_start &&
+         fid_end;
 }
 
 inline bool passes_final_selection(bool pre, bool flash, bool fiducial,

--- a/src/MuonSelector.cc
+++ b/src/MuonSelector.cc
@@ -40,8 +40,9 @@ ROOT::RDF::RNode MuonSelector::build_mask(ROOT::RDF::RNode df) const {
               start_x[i], start_y[i], start_z[i]);
           const bool fid_end = fiducial::is_in_reco_volume(
               end_x[i], end_y[i], end_z[i]);
-          mask[i] = (scores[i] > 0.5f && llr[i] > 0.2f && lengths[i] > 10.0f &&
-                     dists[i] < 4.0f && gens[i] == 2u && fid_start && fid_end);
+          mask[i] = selection::passes_muon_track_selection(
+              scores[i], llr[i], lengths[i], dists[i], gens[i], fid_start,
+              fid_end);
         }
         return mask;
       },


### PR DESCRIPTION
## Summary
- add muon track cut constants to the shared selection header
- reuse the new helper when constructing the muon mask so thresholds live in one place

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbce9dd86c832e9d646df784b0fc8a