### PR TITLE
Expand ROOT dictionary coverage

### DIFF
--- a/src/faintLinkDef.h
+++ b/src/faintLinkDef.h
@@ -1,10 +1,45 @@
+#include "faint/Dataset.h"
 #include "faint/EventProcessor.h"
 #include "faint/MuonSelector.h"
 #include "faint/PreSelection.h"
+#include "faint/Run.h"
+#include "faint/RunReader.h"
+#include "faint/Sample.h"
+#include "faint/SampleSet.h"
+#include "faint/SelectionQuery.h"
+#include "faint/StackedHistogram.h"
 #include "faint/TruthClassifier.h"
+#include "faint/Types.h"
+#include "faint/Variables.h"
+#include "faint/Weighter.h"
 
 #ifdef __CLING__
 #pragma link C++ namespace faint;
+#pragma link C++ namespace faint::dataset;
+#pragma link C++ namespace faint::plot;
+
+#pragma link C++ nestedclasses;
+#pragma link C++ nestedtypedefs;
+
+#pragma link C++ class faint::SampleKey+;
+#pragma link C++ enum faint::SampleOrigin;
+#pragma link C++ enum faint::SampleRole;
+#pragma link C++ enum faint::SampleVariation;
+
+#pragma link C++ class faint::dataset::Options+;
+#pragma link C++ class faint::dataset::Dataset+;
+#pragma link C++ class faint::dataset::Dataset::Entry+;
+#pragma link C++ class faint::dataset::Dataset::Variations+;
+
+#pragma link C++ class faint::Sample+;
+#pragma link C++ class faint::SampleSet+;
+#pragma link C++ class faint::Run+;
+#pragma link C++ class faint::RunReader+;
+#pragma link C++ class faint::SelectionQuery+;
+#pragma link C++ class faint::Variables+;
+#pragma link C++ class faint::Weighter+;
+#pragma link C++ class faint::plot::StackedHistogram+;
+
 #pragma link C++ class faint::EventProcessor+;
 #pragma link C++ class faint::PreSelection+;
 #pragma link C++ class faint::MuonSelector+;


### PR DESCRIPTION
## Summary
- extend the LinkDef to include the dataset, sample management, and plotting classes so ROOT macros can load them
- expose enumerations and nested dataset types to Cling and register additional namespaces used by FAINT

## Testing
- `make -C build faint_root` *(fails: ROOT not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbce145c50832e9b934a1eb5003538