### PR TITLE
Fix ROOT dictionary generation for stacked histogram backgrounds

### DIFF
--- a/include/faint/StackedHistogram.h
+++ b/include/faint/StackedHistogram.h
@@ -32,6 +32,22 @@ class StackedHistogram {
   StackedHistogram(std::string plot_name, std::string output_directory = "plots");
   ~StackedHistogram();
 
+  struct BackgroundComponent {
+    BackgroundComponent();
+    BackgroundComponent(std::string label, std::unique_ptr<TH1> histogram,
+                        Color_t color, Style_t fill_style);
+    BackgroundComponent(const BackgroundComponent& other);
+    BackgroundComponent& operator=(const BackgroundComponent& other);
+    BackgroundComponent(BackgroundComponent&&) noexcept = default;
+    BackgroundComponent& operator=(BackgroundComponent&&) noexcept = default;
+    ~BackgroundComponent() = default;
+
+    std::string label;
+    std::unique_ptr<TH1> histogram;
+    Color_t color{kGray + 1};
+    Style_t fill_style{1001};
+  };
+
   void set_x_axis_title(std::string title);
   void set_y_axis_title(std::string title);
   void set_log_y(bool value);
@@ -66,13 +82,6 @@ class StackedHistogram {
   void draw_and_save(const std::string& format = "png");
 
  private:
-  struct BackgroundComponent {
-    std::string label;
-    std::unique_ptr<TH1> histogram;
-    Color_t color{kGray + 1};
-    Style_t fill_style{1001};
-  };
-
   struct DataComponent {
     std::string label;
     std::unique_ptr<TH1> histogram;


### PR DESCRIPTION
## Summary
- expose `StackedHistogram::BackgroundComponent` publicly and provide copy semantics so ROOT can generate dictionaries
- add a helper to clone background histograms and use `emplace_back` when storing them

## Testing
- make -C build *(fails: missing ROOT headers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd2c5de88832e93f0ace4350ae1cd