### PR TITLE
Rename systematic domain types

### DIFF
--- a/include/faint/selection_manager_adapter.h
+++ b/include/faint/selection_manager_adapter.h
@@ -1,0 +1,33 @@
+#ifndef FAINT_SELECTION_MANAGER_ADAPTER_H
+#define FAINT_SELECTION_MANAGER_ADAPTER_H
+
+#include <string>
+#include <vector>
+
+#include "SelectionManager.h"
+#include "SystematicsHeader.h"
+
+// function (noun)
+inline void systematic_setup(SelectionManager& sel) {
+  // Flux
+  for (size_t i = 0; i < FluxU_Str.size(); ++i)
+    sel.AddSystematic(AllU_SysTypes[sFlux][i], AllU_Universes[sFlux][i], AllU_Str[sFlux][i]);
+
+  // Generator
+  for (size_t i = 0; i < GeneratorU_Str.size(); ++i)
+    sel.AddSystematic(AllU_SysTypes[sGenerator][i], AllU_Universes[sGenerator][i], AllU_Str[sGenerator][i]);
+
+  // Reinteraction
+  for (size_t i = 0; i < ReintU_Str.size(); ++i)
+    sel.AddSystematic(AllU_SysTypes[sReint][i], AllU_Universes[sReint][i], AllU_Str[sReint][i]);
+
+  // Misc
+  for (size_t i = 0; i < MiscU_Str.size(); ++i)
+    sel.AddSystematic(AllU_SysTypes[sMisc][i], AllU_Universes[sMisc][i], AllU_Str[sMisc][i]);
+
+  // Detector
+  for (size_t i = 0; i < DetectorU_Str.size(); ++i)
+    sel.AddSystematic(AllU_SysTypes[sDetector][i], AllU_Universes[sDetector][i], AllU_Str[sDetector][i]);
+}
+
+#endif // FAINT_SELECTION_MANAGER_ADAPTER_H

--- a/include/faint/systematics_rdf.h
+++ b/include/faint/systematics_rdf.h
@@ -1,0 +1,163 @@
+#ifndef FAINT_SYSTEMATICS_RDF_H
+#define FAINT_SYSTEMATICS_RDF_H
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RVec.hxx"
+#include "TH1D.h"
+#include "TH2D.h"
+#include "TMatrixD.h"
+
+#include <faint/systematics_registry.h>
+
+namespace faint {
+namespace syst {
+
+// function (noun phrase)
+inline ROOT::RDF::RNode nominal_weight_node(ROOT::RDF::RNode df) {
+  if (!df.HasColumn("nominal_event_weight"))
+    return df.Define("nominal_event_weight", []() { return 1.0; });
+  return df;
+}
+
+// helper variable (noun)
+static auto weight_product = [](double nom, double w) {
+  const double ww  = (std::isfinite(w) && w > 0.0) ? w : 1.0;
+  const double out = nom * ww;
+  return (std::isfinite(out) && out >= 0.0) ? out : 1.0;
+};
+
+// function (noun phrase)
+inline ROOT::RDF::RNode universe_weight_node(ROOT::RDF::RNode df,
+                                             const SystematicDescriptor& s,
+                                             int universe_index) {
+  auto node = nominal_weight_node(df);
+
+  switch (s.kind) {
+    case SystematicCategory::multisim: {
+      if (!node.HasColumn(s.array_column))
+        return node.Alias("__w", "nominal_event_weight");
+      return node.Define(
+          "__w",
+          [universe_index](double nom, const auto& v) {
+            const double w =
+                (universe_index >= 0 &&
+                 universe_index < static_cast<int>(v.size()))
+                    ? static_cast<double>(v[universe_index])
+                    : 1.0;
+            return weight_product(nom, w);
+          },
+          {"nominal_event_weight", s.array_column});
+    }
+    case SystematicCategory::dual_unisim: {
+      const bool use_up = (universe_index == 1); // 0=down,1=up
+      const std::string& col = use_up ? s.up_column : s.down_column;
+      if (!node.HasColumn(col))
+        return node.Alias("__w", "nominal_event_weight");
+      return node.Define("__w", weight_product,
+                         {"nominal_event_weight", col});
+    }
+    case SystematicCategory::single_unisim: {
+      if (!node.HasColumn(s.single_column))
+        return node.Alias("__w", "nominal_event_weight");
+      return node.Define("__w", weight_product,
+                         {"nominal_event_weight", s.single_column});
+    }
+  }
+  return node;
+}
+
+// function (noun)
+inline ROOT::RDF::RResultPtr<TH1D>
+cv_histogram(ROOT::RDF::RNode df,
+             const ROOT::RDF::TH1DModel& model,
+             const std::string& value_column) {
+  auto node = nominal_weight_node(df).Alias("__w", "nominal_event_weight");
+  return node.Histo1D(model, value_column, "__w");
+}
+
+// function (noun)
+inline std::vector<ROOT::RDF::RResultPtr<TH1D>>
+universe_histograms(ROOT::RDF::RNode df,
+                    const SystematicDescriptor& s,
+                    const ROOT::RDF::TH1DModel& model,
+                    const std::string& value_column) {
+  std::vector<ROOT::RDF::RResultPtr<TH1D>> out;
+  out.reserve(s.universes);
+  for (int u = 0; u < s.universes; ++u) {
+    auto node_u = universe_weight_node(df, s, u);
+    out.emplace_back(node_u.Histo1D(model, value_column, "__w"));
+  }
+  return out;
+}
+
+// function (noun phrase)
+inline TMatrixD covariance_matrix_from_histograms(const TH1D* cv_hist,
+                                                  const std::vector<const TH1D*>& uni_hists,
+                                                  SystematicCategory kind) {
+  const int nb = cv_hist->GetNbinsX();
+  TMatrixD cov(nb, nb);
+
+  auto binv = [](const TH1D* h, int i) { return h->GetBinContent(i + 1); };
+
+  if (kind == SystematicCategory::multisim) {
+    const int n = static_cast<int>(uni_hists.size());
+    if (n < 2) return cov;
+
+    std::vector<double> mean(nb, 0.0);
+    for (int i = 0; i < nb; ++i) {
+      double mi = 0.0;
+      for (int u = 0; u < n; ++u) mi += binv(uni_hists[u], i);
+      mean[i] = mi / n;
+    }
+    for (int i = 0; i < nb; ++i) {
+      for (int j = 0; j < nb; ++j) {
+        double cij = 0.0;
+        for (int u = 0; u < n; ++u) {
+          const double di = binv(uni_hists[u], i) - mean[i];
+          const double dj = binv(uni_hists[u], j) - mean[j];
+          cij += di * dj;
+        }
+        cov[i][j] = cij / (n - 1);
+      }
+    }
+    return cov;
+  }
+
+  if (kind == SystematicCategory::single_unisim) {
+    if (uni_hists.empty()) return cov;
+    const TH1D* h0 = uni_hists.front();
+    for (int i = 0; i < nb; ++i) {
+      const double di = binv(h0, i) - binv(cv_hist, i);
+      for (int j = 0; j < nb; ++j) {
+        const double dj = binv(h0, j) - binv(cv_hist, j);
+        cov[i][j] = di * dj;
+      }
+    }
+    return cov;
+  }
+
+  if (kind == SystematicCategory::dual_unisim) {
+    if (uni_hists.size() < 2) return cov;
+    const TH1D* hdn = uni_hists[0];
+    const TH1D* hup = uni_hists[1];
+    for (int i = 0; i < nb; ++i) {
+      const double di = 0.5 * (binv(hup, i) - binv(hdn, i)); // (up - down)/2
+      for (int j = 0; j < nb; ++j) {
+        const double dj = 0.5 * (binv(hup, j) - binv(hdn, j));
+        cov[i][j] = di * dj;
+      }
+    }
+    return cov;
+  }
+
+  return cov;
+}
+
+} // namespace syst
+} // namespace faint
+
+#endif // FAINT_SYSTEMATICS_RDF_H

--- a/include/faint/systematics_registry.h
+++ b/include/faint/systematics_registry.h
@@ -1,0 +1,70 @@
+#ifndef FAINT_SYSTEMATICS_REGISTRY_H
+#define FAINT_SYSTEMATICS_REGISTRY_H
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <faint/Variables.h>
+
+namespace faint {
+namespace syst {
+
+// domain noun
+enum class SystematicCategory { multisim, single_unisim, dual_unisim };
+
+// domain noun
+struct SystematicDescriptor {
+  std::string name;         // e.g. "weightsGenie", "RPA"
+  SystematicCategory kind;  // multisim / single_unisim / dual_unisim
+  int universes = 0;
+
+  // columns (domain nouns)
+  std::string array_column; // multisim
+  std::string up_column;    // dual_unisim
+  std::string down_column;  // dual_unisim
+  std::string single_column;// single_unisim
+};
+
+// function name: lower_snake_case, noun phrase
+inline std::vector<SystematicDescriptor> systematic_list_from_variables() {
+  std::vector<SystematicDescriptor> out;
+
+  // dual_unisim knobs
+  for (const auto& kv : Variables::knob_var()) {
+    SystematicDescriptor s;
+    s.name        = kv.first;          // "RPA", "CCMEC", ...
+    s.kind        = SystematicCategory::dual_unisim;
+    s.universes   = 2;
+    s.up_column   = kv.second.first;   // e.g. "knobRPAup"
+    s.down_column = kv.second.second;  // e.g. "knobRPAdn"
+    out.push_back(std::move(s));
+  }
+
+  // multisim arrays
+  for (const auto& kv : Variables::multi_uni_var()) {
+    SystematicDescriptor s;
+    s.name         = kv.first;                     // e.g. "weightsGenie"
+    s.kind         = SystematicCategory::multisim;
+    s.universes    = static_cast<int>(kv.second);  // e.g. 500
+    s.array_column = kv.first;                     // same as name
+    out.push_back(std::move(s));
+  }
+
+  // single_unisim (optional one-sided)
+  {
+    SystematicDescriptor s;
+    s.name          = Variables::single_knob_var(); // "RootinoFix"
+    s.kind          = SystematicCategory::single_unisim;
+    s.universes     = 1;
+    s.single_column = s.name;
+    out.push_back(std::move(s));
+  }
+
+  return out;
+}
+
+} // namespace syst
+} // namespace faint
+
+#endif // FAINT_SYSTEMATICS_REGISTRY_H


### PR DESCRIPTION
## Summary
- rename the systematic enum to `SystematicCategory`
- rename the systematic record struct to `SystematicDescriptor`
- update the ROOT helpers to use the new type names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbde544998832ea337d56e5fc80001