### PR TITLE
Rename syst utilities to drop selection manager naming

### DIFF
--- a/include/faint/syst/VariableRegistrySystematics.h
+++ b/include/faint/syst/VariableRegistrySystematics.h
@@ -1,5 +1,5 @@
-#ifndef FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H
-#define FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H
+#ifndef FAINT_SYST_VARIABLE_REGISTRY_SYSTEMATICS_H
+#define FAINT_SYST_VARIABLE_REGISTRY_SYSTEMATICS_H
 
 #include <map>
 #include <string>
@@ -13,7 +13,7 @@ namespace syst {
 using SystematicTable = std::map<SystematicCategory, std::vector<SystematicDescriptor>>;
 
 // function (noun)
-inline const std::vector<SystematicDescriptor>& selection_manager_systematics() {
+inline const std::vector<SystematicDescriptor>& variable_registry_systematics() {
   static const std::vector<SystematicDescriptor> descriptors =
       systematic_list_from_variables();
   return descriptors;
@@ -22,16 +22,16 @@ inline const std::vector<SystematicDescriptor>& selection_manager_systematics() 
 // function (noun phrase)
 inline SystematicTable group_systematics_by_category() {
   SystematicTable grouped;
-  for (const auto& descriptor : selection_manager_systematics())
+  for (const auto& descriptor : variable_registry_systematics())
     grouped[descriptor.kind].push_back(descriptor);
   return grouped;
 }
 
 // function (noun phrase)
-inline std::vector<std::string> selection_manager_systematic_names() {
+inline std::vector<std::string> variable_registry_systematic_names() {
   std::vector<std::string> names;
-  names.reserve(selection_manager_systematics().size());
-  for (const auto& descriptor : selection_manager_systematics())
+  names.reserve(variable_registry_systematics().size());
+  for (const auto& descriptor : variable_registry_systematics())
     names.push_back(descriptor.name);
   return names;
 }
@@ -39,4 +39,4 @@ inline std::vector<std::string> selection_manager_systematic_names() {
 } // namespace syst
 } // namespace faint
 
-#endif // FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H
+#endif // FAINT_SYST_VARIABLE_REGISTRY_SYSTEMATICS_H


### PR DESCRIPTION
## Summary
- rename the syst helper header to VariableRegistrySystematics to avoid selection manager terminology
- update the helper functions to use variable_registry naming to match the new concept

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe6002d9c832ead31d76ed0097177