### PR TITLE
Remove dataset ntuple directory and blind options

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -46,8 +46,6 @@ std::string ntuple_directory(const std::string& run_config_json);
 struct Options {
     std::string beam;
     std::vector<std::string> periods;
-    std::string ntuple_dir;
-    bool blind{true};
 };
 
 class Dataset {
@@ -115,7 +113,7 @@ public:
     const Map& datasets() const noexcept { return datasets_; }
 
 private:
-    Dataset(RunReader runs, Options opt, Variables vars);
+    Dataset(RunReader runs, std::string ntuple_dir, Options opt, Variables vars);
 
     RunReader runs_;
     Variables vars_;

--- a/include/faint/Samples.h
+++ b/include/faint/Samples.h
@@ -70,7 +70,7 @@ class SampleSet {
 
   SampleSet(const RunReader& runs, VariableRegistry variables,
             const std::string& beam, std::vector<std::string> periods,
-            const std::string& ntuple_dir, bool blind = true);
+            const std::string& ntuple_dir);
 
   Map& frames() noexcept;
 
@@ -96,8 +96,6 @@ class SampleSet {
 
   std::string beam_;
   std::vector<std::string> periods_;
-  bool blind_;
-
   double total_pot_;
   long total_triggers_;
 

--- a/install/include/faint/Dataset.h
+++ b/install/include/faint/Dataset.h
@@ -46,8 +46,6 @@ std::string ntuple_directory(const std::string& run_config_json);
 struct Options {
     std::string beam;
     std::vector<std::string> periods;
-    std::string ntuple_dir;
-    bool blind{true};
 };
 
 class Dataset {

--- a/install/include/faint/SampleSet.h
+++ b/install/include/faint/SampleSet.h
@@ -28,7 +28,7 @@ class SampleSet {
 
   SampleSet(const RunReader& runs, VariableRegistry variables,
             const std::string& beam, std::vector<std::string> periods,
-            const std::string& ntuple_dir, bool blind = true);
+            const std::string& ntuple_dir);
 
   Map& frames() noexcept;
 
@@ -54,8 +54,6 @@ class SampleSet {
 
   std::string beam_;
   std::vector<std::string> periods_;
-  bool blind_;
-
   double total_pot_;
   long total_triggers_;
 

--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -22,8 +22,6 @@ void example_macro() {
     faint::dataset::Options options;
     options.beam = "numi-fhc";
     options.periods = {"run1"};
-    options.ntuple_dir = faint::dataset::ntuple_directory();
-
     auto dataset = faint::dataset::Dataset::open(config_path, options);
 
     std::cout << "Loaded beam " << dataset.beam() << " for";

--- a/macros/stacked_histogram_example.C
+++ b/macros/stacked_histogram_example.C
@@ -45,8 +45,6 @@ void stacked_histogram_example() {
     faint::dataset::Options options;
     options.beam = "numi-fhc";
     options.periods = {"run1"};
-    options.ntuple_dir = faint::dataset::ntuple_directory();
-
     auto dataset = faint::dataset::Dataset::open(config_path, options);
 
     faint::plot::StackedHistogram plot("muon_track_length");

--- a/macros/systematics_error_band_example.C
+++ b/macros/systematics_error_band_example.C
@@ -57,8 +57,6 @@ void systematics_error_band_example() {
     faint::dataset::Options options;
     options.beam = "numi-fhc";
     options.periods = {"run1"};
-    options.ntuple_dir = faint::dataset::ntuple_directory();
-
     auto dataset = faint::dataset::Dataset::open(config_path, options);
 
     const auto sample_key = find_mc_sample_key(dataset);

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -11,12 +11,12 @@
 namespace faint {
 namespace dataset {
 
-Dataset::Dataset(RunReader runs, Options opt, Variables vars)
+Dataset::Dataset(RunReader runs, std::string ntuple_dir, Options opt, Variables vars)
     : runs_(std::move(runs)),
       vars_(std::move(vars)),
       opt_(std::move(opt)),
       set_(std::make_unique<SampleSet>(runs_, vars_, opt_.beam, opt_.periods,
-                                       opt_.ntuple_dir, opt_.blind)) {
+                                       ntuple_dir)) {
     build_dataset_cache();
 }
 
@@ -60,7 +60,9 @@ std::string ntuple_directory(const std::string& run_config_json) {
 }
 
 Dataset Dataset::open(const std::string& run_config_json, Options opt, Variables vars) {
-    return Dataset(RunReader(run_config_json), std::move(opt), std::move(vars));
+    auto ntuple_dir = ntuple_directory(run_config_json);
+    return Dataset(RunReader(run_config_json), std::move(ntuple_dir), std::move(opt),
+                   std::move(vars));
 }
 
 std::vector<std::string> Dataset::sample_keys(

--- a/src/Samples.cc
+++ b/src/Samples.cc
@@ -149,13 +149,12 @@ ROOT::RDF::RNode Sample::build(const std::string& base_dir,
 
 SampleSet::SampleSet(const RunReader& runs, VariableRegistry variables,
                      const std::string& beam, std::vector<std::string> periods,
-                     const std::string& ntuple_dir, bool blind)
+                     const std::string& ntuple_dir)
     : runs_(runs),
       variables_(std::move(variables)),
       ntuple_dir_(ntuple_dir),
       beam_(beam),
       periods_(std::move(periods)),
-      blind_(blind),
       total_pot_(0.0),
       total_triggers_(0) {
   build();


### PR DESCRIPTION
## Summary
- compute the ntuple directory internally when creating datasets
- simplify the sample set API by removing the unused blind flag
- update example macros to rely on automatic ntuple directory discovery

## Testing
- ninja -C build *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeccdf688832eaff8e6b7b1182590