### PR TITLE
Move dataset constants to selection namespace

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -23,20 +23,6 @@
 namespace faint {
 namespace dataset {
 
-namespace sel {
-inline constexpr const char* Pre = selection::column::kPassPre;
-inline constexpr const char* Flash = selection::column::kPassFlash;
-inline constexpr const char* FV = selection::column::kPassFiducial;
-inline constexpr const char* Muon = selection::column::kPassMuon;
-inline constexpr const char* Topo = selection::column::kPassTopology;
-inline constexpr const char* Final = selection::column::kPassFinal;
-inline constexpr const char* Quality = selection::column::kQualityEvent;
-}
-
-namespace col {
-inline constexpr const char* Weight = "nominal_event_weight";
-}
-
 std::string run_config_path();
 
 std::string ntuple_directory();

--- a/include/faint/Selection.h
+++ b/include/faint/Selection.h
@@ -19,6 +19,20 @@ namespace column {
   inline constexpr const char *kQualityEvent = "quality_event";
 } // namespace column
 
+namespace sel {
+  inline constexpr const char *Pre = column::kPassPre;
+  inline constexpr const char *Flash = column::kPassFlash;
+  inline constexpr const char *FV = column::kPassFiducial;
+  inline constexpr const char *Muon = column::kPassMuon;
+  inline constexpr const char *Topo = column::kPassTopology;
+  inline constexpr const char *Final = column::kPassFinal;
+  inline constexpr const char *Quality = column::kQualityEvent;
+} // namespace sel
+
+namespace col {
+  inline constexpr const char *Weight = "nominal_event_weight";
+} // namespace col
+
 struct PreCut {
   static constexpr float kMinBeamPE = 0.f;
   static constexpr float kMaxVetoPE = 20.f;

--- a/include/faint/Selections.h
+++ b/include/faint/Selections.h
@@ -18,6 +18,20 @@ inline constexpr const char *kPassFinal = "pass_final";
 inline constexpr const char *kQualityEvent = "quality_event";
 } // namespace column
 
+namespace sel {
+inline constexpr const char *Pre = column::kPassPre;
+inline constexpr const char *Flash = column::kPassFlash;
+inline constexpr const char *FV = column::kPassFiducial;
+inline constexpr const char *Muon = column::kPassMuon;
+inline constexpr const char *Topo = column::kPassTopology;
+inline constexpr const char *Final = column::kPassFinal;
+inline constexpr const char *Quality = column::kQualityEvent;
+} // namespace sel
+
+namespace col {
+inline constexpr const char *Weight = "nominal_event_weight";
+} // namespace col
+
 struct PreCut {
   static constexpr float kMinBeamPE = 0.f;
   static constexpr float kMaxVetoPE = 20.f;

--- a/install/include/faint/Dataset.h
+++ b/install/include/faint/Dataset.h
@@ -23,20 +23,6 @@
 namespace faint {
 namespace dataset {
 
-namespace sel {
-inline constexpr const char* Pre = selection::column::kPassPre;
-inline constexpr const char* Flash = selection::column::kPassFlash;
-inline constexpr const char* FV = selection::column::kPassFiducial;
-inline constexpr const char* Muon = selection::column::kPassMuon;
-inline constexpr const char* Topo = selection::column::kPassTopology;
-inline constexpr const char* Final = selection::column::kPassFinal;
-inline constexpr const char* Quality = selection::column::kQualityEvent;
-}
-
-namespace col {
-inline constexpr const char* Weight = "nominal_event_weight";
-}
-
 std::string run_config_path();
 
 std::string ntuple_directory();

--- a/install/include/faint/Selections.h
+++ b/install/include/faint/Selections.h
@@ -18,6 +18,20 @@ inline constexpr const char *kPassFinal = "pass_final";
 inline constexpr const char *kQualityEvent = "quality_event";
 } // namespace column
 
+namespace sel {
+inline constexpr const char *Pre = column::kPassPre;
+inline constexpr const char *Flash = column::kPassFlash;
+inline constexpr const char *FV = column::kPassFiducial;
+inline constexpr const char *Muon = column::kPassMuon;
+inline constexpr const char *Topo = column::kPassTopology;
+inline constexpr const char *Final = column::kPassFinal;
+inline constexpr const char *Quality = column::kQualityEvent;
+} // namespace sel
+
+namespace col {
+inline constexpr const char *Weight = "nominal_event_weight";
+} // namespace col
+
 struct PreCut {
   static constexpr float kMinBeamPE = 0.f;
   static constexpr float kMaxVetoPE = 20.f;

--- a/macros/stacked_histogram_example.C
+++ b/macros/stacked_histogram_example.C
@@ -65,7 +65,7 @@ void stacked_histogram_example() {
         const std::string hist_name = "hist_" + key;
         auto node = dataset.final(key);
         auto hist = node.Histo1D(make_hist_model(hist_name, key), "track_length",
-                                 faint::dataset::col::Weight);
+                                 faint::selection::col::Weight);
         const Color_t color = palette[color_index % palette.size()];
         ++color_index;
         plot.add_background(*hist, prettify_label(key), color, 1001);
@@ -83,7 +83,7 @@ void stacked_histogram_example() {
       auto node = dataset.final(key);
       auto hist =
           node.Histo1D(make_hist_model(hist_name, key), "track_length",
-                       faint::dataset::col::Weight);
+                       faint::selection::col::Weight);
       plot.set_data(*hist, "Data", kBlack, 20);
     }
 


### PR DESCRIPTION
## Summary
- expose the selection pass and weight column constants from the selection headers instead of the dataset header
- update the stacked histogram example macro to use the selection namespace constants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbecdcb7e4832eac13bf3a3a0e8982