### PR TITLE
Expose selection weight column constant and update example

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -23,20 +23,6 @@
 namespace faint {
 namespace dataset {
 
-namespace sel {
-inline constexpr const char* Pre = selection::column::kPassPre;
-inline constexpr const char* Flash = selection::column::kPassFlash;
-inline constexpr const char* FV = selection::column::kPassFiducial;
-inline constexpr const char* Muon = selection::column::kPassMuon;
-inline constexpr const char* Topo = selection::column::kPassTopology;
-inline constexpr const char* Final = selection::column::kPassFinal;
-inline constexpr const char* Quality = selection::column::kQualityEvent;
-}
-
-namespace col {
-inline constexpr const char* Weight = "nominal_event_weight";
-}
-
 std::string run_config_path();
 
 std::string ntuple_directory();

--- a/include/faint/Selection.h
+++ b/include/faint/Selection.h
@@ -17,6 +17,7 @@ namespace column {
   inline constexpr const char *kPassTopology = "pass_topo";
   inline constexpr const char *kPassFinal = "pass_final";
   inline constexpr const char *kQualityEvent = "quality_event";
+  inline constexpr const char *kNominalWeight = "nominal_event_weight";
 } // namespace column
 
 struct PreCut {

--- a/macros/stacked_histogram_example.C
+++ b/macros/stacked_histogram_example.C
@@ -5,6 +5,7 @@
 
 #include <faint/Dataset.h>
 #include <faint/Log.h>
+#include <faint/Selection.h>
 #include <faint/Types.h>
 #include <faint/plot/StackedHistogram.h>
 
@@ -63,7 +64,7 @@ void stacked_histogram_example() {
         const std::string hist_name = "hist_" + key;
         auto node = dataset.final(key);
         auto hist = node.Histo1D(make_hist_model(hist_name, key), "track_length",
-                                 faint::dataset::col::Weight);
+                                 faint::selection::column::kNominalWeight);
         const Color_t color = palette[color_index % palette.size()];
         ++color_index;
         plot.add_background(*hist, prettify_label(key), color, 1001);
@@ -81,7 +82,7 @@ void stacked_histogram_example() {
       auto node = dataset.final(key);
       auto hist =
           node.Histo1D(make_hist_model(hist_name, key), "track_length",
-                       faint::dataset::col::Weight);
+                       faint::selection::column::kNominalWeight);
       plot.set_data(*hist, "Data", kBlack, 20);
     }
 


### PR DESCRIPTION
## Summary
- add the nominal event weight identifier to the selection column constants and drop the redundant dataset aliases
- switch the stacked histogram macro to the selection namespace constant for histogram weights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbee3ff9e8832ea810c07c06d06179