### PR TITLE
Fix Processor include paths

### DIFF
--- a/src/Processor.cc
+++ b/src/Processor.cc
@@ -1,5 +1,5 @@
-#include "Processor.hh"
-#include "Hub.hh"
+#include "rarexsec/Processor.hh"
+#include "rarexsec/Hub.hh"
 #include <cmath>
 
 ROOT::RDF::RNode rarexsec::Processor::run(ROOT::RDF::RNode node, const rarexsec::Entry rec) const {


### PR DESCRIPTION
## Summary
- include Processor and Hub headers using their namespace-qualified paths so they can be found during compilation

## Testing
- make *(fails: root-config not found in PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de9e9f4610832e983dc16f481c9cdc