### PR TITLE
Capture chosen nlohmann_json include flag

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -41,6 +41,21 @@ else
 CXXFLAGS+=-std=$(CXXSTD)
 endif
 CPPFLAGS+=$(shell $(ROOTCONFIG) --cflags)
+
+# Attempt to locate nlohmann_json provided by the environment setup.
+JSON_INCLUDE_FLAG:=
+ifneq ($(strip $(NLOHMANN_JSON_CFLAGS)),)
+JSON_INCLUDE_FLAG:=$(NLOHMANN_JSON_CFLAGS)
+else ifneq ($(strip $(NLOHMANN_JSON_INC)),)
+JSON_INCLUDE_FLAG:=-I$(NLOHMANN_JSON_INC)
+else ifneq ($(strip $(NLOHMANN_JSON_INCLUDE_DIRS)),)
+JSON_INCLUDE_FLAG:=-I$(NLOHMANN_JSON_INCLUDE_DIRS)
+else ifneq ($(strip $(NLOHMANN_JSON_FQ_DIR)),)
+JSON_INCLUDE_FLAG:=-I$(NLOHMANN_JSON_FQ_DIR)/include
+else ifneq ($(strip $(NLOHMANN_JSON_DIR)),)
+JSON_INCLUDE_FLAG:=-I$(NLOHMANN_JSON_DIR)/include
+endif
+CPPFLAGS+=$(JSON_INCLUDE_FLAG)
 LDFLAGS+=$(shell $(ROOTCONFIG) --ldflags)
 LDLIBS+=$(shell $(ROOTCONFIG) --libs)
 
@@ -115,6 +130,7 @@ print:
 	@echo SHARED=$(SHARED)
 	@echo STATIC=$(STATIC)
 	@echo SOEXT=$(SOEXT)
+	@echo JSON_INCLUDE_FLAG=$(JSON_INCLUDE_FLAG)
 
 clean:
 	@rm -rf $(OBJ) $(LIB) $(BIN)


### PR DESCRIPTION
## Summary
- capture the UPS-provided nlohmann_json flag that is discovered and append it to the build
- expose the resolved JSON include flag via `make print` for quick inspection

## Testing
- make -C build print *(fails in this environment because `root-config` is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68de9f6b6e74832e8d22e87042979767