### PR TITLE
Copy exposure fields into detvar samples

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -58,7 +58,7 @@ private:
     beamline_map db_;
 
     static Data sample(const Entry& rec);
-    static Data sample(const std::string& file, sample::origin kind);
+    static Data sample(const std::string& file, sample::origin kind, const Entry& prototype);
 };
 
 }

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -56,7 +56,7 @@ rarexsec::Hub::Hub(const std::string& path) {
                         const auto& desc = it_dv.value();
                         const std::string dv_file = desc.at("file").get<std::string>();
                         if (!dv_file.empty()) {
-                            rec.detvars.emplace(tag, sample(dv_file, rec.kind));
+                            rec.detvars.emplace(tag, sample(dv_file, rec.kind, rec));
                         }
                     }
                 }
@@ -67,10 +67,12 @@ rarexsec::Hub::Hub(const std::string& path) {
     }
 }
 
-rarexsec::Data rarexsec::Hub::sample(const std::string& file, sample::origin kind) {
-    Entry rec;
+rarexsec::Data rarexsec::Hub::sample(const std::string& file, sample::origin kind, const Entry& prototype) {
+    Entry rec = prototype;
     rec.file = file;
     rec.kind = kind;
+    rec.nominal = {};
+    rec.detvars.clear();
     return sample(rec);
 }
 


### PR DESCRIPTION
## Summary
- copy the nominal entry's exposure metadata when instantiating detector-variation samples
- clear previously populated data before delegating to the shared sample loader

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea358c8a0832ebf0aabbd99bf4480