### PR TITLE
Fix rarexsec Hub type references

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -48,12 +48,12 @@ class Hub {
 public:
     explicit Hub(const std::string& path);
 
-    std::vector<const Entry*> simulation(const std::string& beamline,
-                                         const std::vector<std::string>& periods) const;
+    std::vector<const rarexsec::Entry*> simulation(const std::string& beamline,
+                                                   const std::vector<std::string>& periods) const;
 
 
 private:
-    using period_map   = std::unordered_map<std::string, std::vector<Entry>>;
+    using period_map   = std::unordered_map<std::string, std::vector<rarexsec::Entry>>;
     using beamline_map = std::unordered_map<std::string, period_map>;
     beamline_map db_;
 


### PR DESCRIPTION
## Summary
- ensure Hub.hh uses the rarexsec::Entry type when declaring simulation results
- update internal period map alias to store rarexsec entries explicitly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea38f24f0832e9320697952c1e203