### PR TITLE
Add helper for derived sample entries

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -31,12 +31,20 @@ struct Entry {
     std::string period;
     sample::origin kind = sample::origin::unknown;
     std::string file;
-    double pot      = 0.0; 
-    double pot_eff  = 0.0; 
-    double trig     = 0.0; 
-    double trig_eff = 0.0; 
+    double pot      = 0.0;
+    double pot_eff  = 0.0;
+    double trig     = 0.0;
+    double trig_eff = 0.0;
     Data nominal;
     std::unordered_map<std::string, Data> detvars;
+    Entry stripped_copy(const std::string& new_file, sample::origin new_kind) const {
+        Entry copy = *this;
+        copy.file = new_file;
+        copy.kind = new_kind;
+        copy.nominal = {};
+        copy.detvars.clear();
+        return copy;
+    }
     const ROOT::RDF::RNode& rnode() const { return nominal.node; }
     const Data* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -68,12 +68,7 @@ rarexsec::Hub::Hub(const std::string& path) {
 }
 
 rarexsec::Data rarexsec::Hub::sample(const std::string& file, sample::origin kind, const Entry& prototype) {
-    Entry rec = prototype;
-    rec.file = file;
-    rec.kind = kind;
-    rec.nominal = {};
-    rec.detvars.clear();
-    return sample(rec);
+    return sample(prototype.stripped_copy(file, kind));
 }
 
 std::vector<const rarexsec::Entry*> rarexsec::Hub::simulation(const std::string& beamline,


### PR DESCRIPTION
## Summary
- add an Entry helper to clone prototypes with new file and origin
- simplify the Hub::sample overload to use the helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea4b22e74832e9916441a94ab7dc9