### PR TITLE
Fix indentation in Makefile config generation rule

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -95,8 +95,12 @@ $(AR) rcs $@ $^
 @echo Built $@
 
 $(CONFIG_OUT): $(CONFIG_IN) | $(BIN)
-sed -e 's|@@VERSION@@|$(VERSION)|g' -e 's|@@GIT_REVISION@@|$(GIT_REV)|g' -e 's|@@CXX_STD@@|$(CXXSTD)|g' -e 's|@@USE_ROOT@@|yes|g' $< > $@
-chmod +x $@
+	sed -e 's|@@VERSION@@|$(VERSION)|g' \
+	    -e 's|@@GIT_REVISION@@|$(GIT_REV)|g' \
+	    -e 's|@@CXX_STD@@|$(CXXSTD)|g' \
+	    -e 's|@@USE_ROOT@@|yes|g' \
+	    $< > $@
+	chmod +x $@
 
 PREFIX?=$(TOP)/install
 INSTALL_LIB:=$(PREFIX)/lib


### PR DESCRIPTION
## Summary
- correct the sed command rule in build/Makefile by restoring proper tab-indented recipe lines
- format the configuration generation step with line continuations for clarity

## Testing
- `make` *(fails: root-config not found in PATH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea4d828d8832e8a53cb74e3d1d85a