### PR TITLE
Update example macro to use Hub API

### DIFF
--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -1,7 +1,7 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
 #include <TSystem.h>
-#include <rarexsec/Dataset.h>
+#include <rarexsec/Hub.hh>
 
 #include <iostream>
 #include <stdexcept>
@@ -17,26 +17,69 @@ void example_macro() {
     }
 
     const std::string config_path = "data/samples.json";
+    const std::string beamline = "numi-fhc";
+    const std::vector<std::string> periods = {"run1"};
 
-    rarexsec::dataset::Options options;
-    options.beam = "numi-fhc";
-    options.periods = {"run1"};
-    auto dataset = rarexsec::dataset::Dataset::open(config_path, options);
+    rarexsec::Hub hub(config_path);
+    const auto samples = hub.simulation(beamline, periods);
 
-    std::cout << "Loaded beam " << dataset.beam() << " for";
-    for (const auto& period : dataset.periods()) {
+    std::cout << "Loaded beamline " << beamline << " for";
+    for (const auto& period : periods) {
       std::cout << ' ' << period;
     }
-    std::cout << " with " << dataset.sample_keys().size() << " samples." << std::endl;
+    std::cout << " with " << samples.size() << " simulation samples." << std::endl;
 
-    for (const auto& key : dataset.sample_keys()) {
-      auto final_count = dataset.final(key).Count();
+    auto origin_to_string = [](rarexsec::sample::origin kind) {
+      switch (kind) {
+      case rarexsec::sample::origin::data:
+        return "data";
+      case rarexsec::sample::origin::beam:
+        return "beam";
+      case rarexsec::sample::origin::strangeness:
+        return "strangeness";
+      case rarexsec::sample::origin::ext:
+        return "ext";
+      case rarexsec::sample::origin::dirt:
+        return "dirt";
+      case rarexsec::sample::origin::unknown:
+      default:
+        return "unknown";
+      }
+    };
+
+    double total_pot = 0.0;
+    double total_pot_eff = 0.0;
+    double total_triggers = 0.0;
+    double total_triggers_eff = 0.0;
+
+    for (const auto* entry : samples) {
+      if (!entry) {
+        continue;
+      }
+
+      std::cout << "Sample kind '" << origin_to_string(entry->kind) << "' from file "
+                << entry->file << std::endl;
+
+      auto final_count = entry->rnode().Count();
       auto eval_final_count = final_count.GetValue();
-      std::cout << "Final selection entries for " << key << ": " << eval_final_count << std::endl;
+      std::cout << "  Final selection entries: " << eval_final_count << std::endl;
+
+      for (const auto& detvar : entry->detvars) {
+        auto detvar_count = detvar.second.node.Count().GetValue();
+        std::cout << "  Detector variation '" << detvar.first
+                  << "' entries: " << detvar_count << std::endl;
+      }
+
+      total_pot += entry->pot;
+      total_pot_eff += (entry->pot_eff > 0.0) ? entry->pot_eff : entry->pot;
+      total_triggers += entry->trig;
+      total_triggers_eff += (entry->trig_eff > 0.0) ? entry->trig_eff : entry->trig;
     }
 
-    std::cout << "Total POT: " << dataset.pot() << std::endl;
-    std::cout << "Total triggers: " << dataset.triggers() << std::endl;
+    std::cout << "Total POT (nominal): " << total_pot << std::endl;
+    std::cout << "Total POT (effective): " << total_pot_eff << std::endl;
+    std::cout << "Total triggers (nominal): " << total_triggers << std::endl;
+    std::cout << "Total triggers (effective): " << total_triggers_eff << std::endl;
   } catch (const std::exception& ex) {
     std::cerr << "Error: " << ex.what() << std::endl;
   }


### PR DESCRIPTION
## Summary
- switch the example ROOT macro from the deprecated Dataset helper to the new Hub interface
- add reporting of sample origins, detector variation counts, and nominal/effective POT and trigger totals

## Testing
- not run (documentation/example change)


------
https://chatgpt.com/codex/tasks/task_e_68dea7c744a4832ebad806a13744431a