### PR TITLE
Remove stripped detvar helper

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -37,14 +37,6 @@ struct Entry {
     double trig_eff = 0.0;
     Data nominal;
     std::unordered_map<std::string, Data> detvars;
-    Entry stripped_copy(const std::string& new_file, sample::origin new_kind) const {
-        Entry copy = *this;
-        copy.file = new_file;
-        copy.kind = new_kind;
-        copy.nominal = {};
-        copy.detvars.clear();
-        return copy;
-    }
     const ROOT::RDF::RNode& rnode() const { return nominal.node; }
     const Data* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);
@@ -66,7 +58,6 @@ private:
     beamline_map db_;
 
     static Data sample(const Entry& rec);
-    static Data sample(const std::string& file, sample::origin kind, const Entry& prototype);
 };
 
 }

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -56,7 +56,9 @@ rarexsec::Hub::Hub(const std::string& path) {
                         const auto& desc = it_dv.value();
                         const std::string dv_file = desc.at("file").get<std::string>();
                         if (!dv_file.empty()) {
-                            rec.detvars.emplace(tag, sample(dv_file, rec.kind, rec));
+                            Entry dv = rec;
+                            dv.file = dv_file;
+                            rec.detvars.emplace(tag, sample(dv));
                         }
                     }
                 }
@@ -65,10 +67,6 @@ rarexsec::Hub::Hub(const std::string& path) {
             }
         }
     }
-}
-
-rarexsec::Data rarexsec::Hub::sample(const std::string& file, sample::origin kind, const Entry& prototype) {
-    return sample(prototype.stripped_copy(file, kind));
 }
 
 std::vector<const rarexsec::Entry*> rarexsec::Hub::simulation(const std::string& beamline,


### PR DESCRIPTION
## Summary
- drop the Entry::stripped_copy helper now that detvar sampling reuses full entries
- remove the unused Hub::sample overload that relied on the stripped copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea8a006cc832ea6a52b5ef2fd5272